### PR TITLE
cleanup and primary keys

### DIFF
--- a/examples/user-session/__generated__/actions.ts
+++ b/examples/user-session/__generated__/actions.ts
@@ -53,17 +53,29 @@ export interface QueryNodeArgs {
 
 /** SimpleModels are DynamoDB with a key schema that does not include a sort key. */
 export interface SimpleModel {
-  /** Set automatically when the item is first written */
   createdAt: Scalars['Date'];
   id: Scalars['ID'];
-  /** Set automatically when the item is updated */
   updatedAt: Scalars['Date'];
   version: Scalars['Int'];
 }
 
+/**
+ * Automatically adds a createdAt and updatedAt timestamp to the entity and sets
+ * them appropriately. The createdAt timestamp is only set on create, while the
+ * updatedAt timestamp is set on create and update.
+ */
+export interface Timestamped {
+  /** Set automatically when the item is first written */
+  createdAt: Scalars['Date'];
+  /** Set automatically when the item is updated */
+  updatedAt: Scalars['Date'];
+}
+
 /** A user session object. */
 export type UserSession = Node &
-  SimpleModel & {
+  SimpleModel &
+  Timestamped &
+  Versioned & {
     __typename?: 'UserSession';
     createdAt: Scalars['Date'];
     expires: Scalars['Date'];
@@ -72,6 +84,15 @@ export type UserSession = Node &
     updatedAt: Scalars['Date'];
     version: Scalars['Int'];
   };
+
+/**
+ * Automatically adds a column to enable optimistic locking. This field shouldn't
+ * be manipulated directly, but may need to be passed around by the runtime in
+ * order to make updates.
+ */
+export interface Versioned {
+  version: Scalars['Int'];
+}
 
 export interface ResultType<T> {
   capacity: ConsumedCapacity;

--- a/examples/user-session/schema/user-session.graphqls
+++ b/examples/user-session/schema/user-session.graphqls
@@ -1,7 +1,8 @@
 """
 A user session object.
 """
-type UserSession implements Node & SimpleModel @consistent {
+type UserSession implements Node & SimpleModel & Timestamped & Versioned
+  @consistent {
   createdAt: Date!
   expires: Date! @ttl(duration: "1d")
   id: ID!

--- a/examples/user-session/user-session.test.ts
+++ b/examples/user-session/user-session.test.ts
@@ -59,7 +59,7 @@ describe('createUserSession()', () => {
     expect(result.item.updatedAt.getTime()).not.toBeNaN();
 
     // cleanup, not part of test
-    await deleteUserSession(result.item.id);
+    await deleteUserSession(result.item);
   });
 });
 
@@ -67,7 +67,7 @@ describe('deleteUserSession()', () => {
   it('deletes a record', async () => {
     const result = await createUserSession({session: {foo: 'foo'}});
 
-    const deleteResult = await deleteUserSession(result.item.id);
+    const deleteResult = await deleteUserSession(result.item);
     expect(deleteResult).toMatchInlineSnapshot(
       {capacity: {TableName: expect.any(String)}},
       `
@@ -92,13 +92,13 @@ describe('deleteUserSession()', () => {
     );
 
     await expect(
-      async () => await readUserSession(result.item.id)
+      async () => await readUserSession(result.item)
     ).rejects.toThrow(NotFoundError);
   });
 
   it('throws an error if the record does not exist', async () => {
     await expect(
-      async () => await deleteUserSession('some-id')
+      async () => await deleteUserSession({id: 'some-id'})
     ).rejects.toThrow(NotFoundError);
   });
 });
@@ -107,7 +107,7 @@ describe('readUserSession()', () => {
   it('reads a record', async () => {
     const result = await createUserSession({session: {foo: 'foo'}});
 
-    const readResult = await readUserSession(result.item.id);
+    const readResult = await readUserSession(result.item);
     expect(readResult).toMatchInlineSnapshot(
       userSessionMatcher,
       `
@@ -141,13 +141,13 @@ describe('readUserSession()', () => {
     );
 
     // cleanup, not part of test
-    await deleteUserSession(result.item.id);
+    await deleteUserSession(result.item);
   });
 
   it('throws an error if the record does not exist', async () => {
-    await expect(async () => await readUserSession('some-id')).rejects.toThrow(
-      NotFoundError
-    );
+    await expect(
+      async () => await readUserSession({id: 'some-id'})
+    ).rejects.toThrow(NotFoundError);
   });
 });
 
@@ -155,7 +155,7 @@ describe('touchUserSession()', () => {
   it("updates a record's createdAt and extends its ttl", async () => {
     const result = await createUserSession({session: {foo: 'foo'}});
 
-    const readResult = await readUserSession(result.item.id);
+    const readResult = await readUserSession(result.item);
     expect(readResult).toMatchInlineSnapshot(
       userSessionMatcher,
       `
@@ -188,8 +188,8 @@ describe('touchUserSession()', () => {
     `
     );
 
-    await touchUserSession(result.item.id);
-    const touchResult = await readUserSession(result.item.id);
+    await touchUserSession(result.item);
+    const touchResult = await readUserSession(result.item);
     expect(touchResult).toMatchInlineSnapshot(
       userSessionMatcher,
       `
@@ -228,13 +228,13 @@ describe('touchUserSession()', () => {
     expect(readResult.item.expires).not.toEqual(touchResult.item.expires);
 
     // cleanup, not part of test
-    await deleteUserSession(result.item.id);
+    await deleteUserSession(result.item);
   });
 
   it('throws an error if the record does not exist', async () => {
-    await expect(async () => await touchUserSession('some-id')).rejects.toThrow(
-      NotFoundError
-    );
+    await expect(
+      async () => await touchUserSession({id: 'some-id'})
+    ).rejects.toThrow(NotFoundError);
   });
 });
 
@@ -311,7 +311,7 @@ describe('updateUserSession()', () => {
     );
     expect(updateResult.item.session).toEqual({foo: 'bar'});
 
-    const readResult = await readUserSession(createResult.item.id);
+    const readResult = await readUserSession(createResult.item);
     expect(readResult).toMatchInlineSnapshot(
       userSessionMatcher,
       `
@@ -349,7 +349,7 @@ describe('updateUserSession()', () => {
     expect(readResult.item.updatedAt).toEqual(updateResult.item.updatedAt);
 
     // cleanup, not part of test
-    await deleteUserSession(createResult.item.id);
+    await deleteUserSession(createResult.item);
   });
 
   it('throws an error if the record does not exist', async () => {
@@ -379,6 +379,6 @@ describe('updateUserSession()', () => {
     ).rejects.toThrow(OptimisticLockingError);
 
     // cleanup, not part of test
-    await deleteUserSession(createResult.item.id);
+    await deleteUserSession(createResult.item);
   });
 });

--- a/examples/user-session/user-session.test.ts
+++ b/examples/user-session/user-session.test.ts
@@ -18,7 +18,7 @@ const userSessionMatcher = {
   },
 };
 describe('createUserSession()', () => {
-  it('creates a user session', async () => {
+  it('creates a record', async () => {
     const result = await createUserSession({session: {foo: 'foo'}});
 
     expect(result).toMatchInlineSnapshot(
@@ -64,7 +64,7 @@ describe('createUserSession()', () => {
 });
 
 describe('deleteUserSession()', () => {
-  it('deletes a user session', async () => {
+  it('deletes a record', async () => {
     const result = await createUserSession({session: {foo: 'foo'}});
 
     const deleteResult = await deleteUserSession(result.item.id);
@@ -96,7 +96,7 @@ describe('deleteUserSession()', () => {
     ).rejects.toThrow(NotFoundError);
   });
 
-  it('throws an error if the user session does not exist', async () => {
+  it('throws an error if the record does not exist', async () => {
     await expect(
       async () => await deleteUserSession('some-id')
     ).rejects.toThrow(NotFoundError);
@@ -104,7 +104,7 @@ describe('deleteUserSession()', () => {
 });
 
 describe('readUserSession()', () => {
-  it('reads a user session', async () => {
+  it('reads a record', async () => {
     const result = await createUserSession({session: {foo: 'foo'}});
 
     const readResult = await readUserSession(result.item.id);
@@ -144,7 +144,7 @@ describe('readUserSession()', () => {
     await deleteUserSession(result.item.id);
   });
 
-  it('throws an error if the user session does not exist', async () => {
+  it('throws an error if the record does not exist', async () => {
     await expect(async () => await readUserSession('some-id')).rejects.toThrow(
       NotFoundError
     );
@@ -152,7 +152,7 @@ describe('readUserSession()', () => {
 });
 
 describe('touchUserSession()', () => {
-  it("updates a user session's createdAt and extends its ttl", async () => {
+  it("updates a record's createdAt and extends its ttl", async () => {
     const result = await createUserSession({session: {foo: 'foo'}});
 
     const readResult = await readUserSession(result.item.id);
@@ -231,7 +231,7 @@ describe('touchUserSession()', () => {
     await deleteUserSession(result.item.id);
   });
 
-  it('throws an error if the user session does not exist', async () => {
+  it('throws an error if the record does not exist', async () => {
     await expect(async () => await touchUserSession('some-id')).rejects.toThrow(
       NotFoundError
     );
@@ -239,7 +239,7 @@ describe('touchUserSession()', () => {
 });
 
 describe('updateUserSession()', () => {
-  it('updates a user session', async () => {
+  it('updates a record', async () => {
     const createResult = await createUserSession({session: {foo: 'foo'}});
     expect(createResult).toMatchInlineSnapshot(
       userSessionMatcher,
@@ -352,7 +352,7 @@ describe('updateUserSession()', () => {
     await deleteUserSession(createResult.item.id);
   });
 
-  it('throws an error if the user session does not exist', async () => {
+  it('throws an error if the record does not exist', async () => {
     await expect(
       async () =>
         await updateUserSession({
@@ -363,7 +363,7 @@ describe('updateUserSession()', () => {
     ).rejects.toThrow(NotFoundError);
   });
 
-  it('throws an error if the loaded session data is out of date', async () => {
+  it('throws an error if the loaded record is out of date', async () => {
     const createResult = await createUserSession({session: {foo: 'foo'}});
     await updateUserSession({
       ...createResult.item,

--- a/src/codegen/actions/plugin.ts
+++ b/src/codegen/actions/plugin.ts
@@ -6,7 +6,9 @@ import {
   AddToSchemaResult,
   PluginFunction,
 } from '@graphql-codegen/plugin-helpers';
-import {assertObjectType, GraphQLObjectType} from 'graphql';
+import {assertObjectType, GraphQLObjectType, isObjectType} from 'graphql';
+
+import {hasInterface} from '../common/helpers';
 
 import {ActionPluginConfig} from './config';
 import {
@@ -34,12 +36,7 @@ export const plugin: PluginFunction<ActionPluginConfig> = (
   const simpleTableTypes = Object.keys(typesMap)
     .filter((typeName) => {
       const type = typesMap[typeName];
-      const {astNode} = type;
-
-      return (
-        astNode?.kind === 'ObjectTypeDefinition' &&
-        astNode.interfaces?.map(({name}) => name.value).includes('SimpleModel')
-      );
+      return isObjectType(type) && hasInterface('SimpleModel', type);
     })
     .map((typeName) => {
       const objType = typesMap[typeName];

--- a/src/codegen/actions/plugin.ts
+++ b/src/codegen/actions/plugin.ts
@@ -17,7 +17,7 @@ import {
   readItemTemplate,
   touchItemTemplate,
   updateItemTemplate,
-} from './tables/simple-table';
+} from './tables/table';
 
 /** @override */
 export function addToSchema(): AddToSchemaResult {

--- a/src/codegen/actions/plugin.ts
+++ b/src/codegen/actions/plugin.ts
@@ -44,26 +44,30 @@ export const plugin: PluginFunction<ActionPluginConfig> = (
       return objType;
     });
 
-  const content = simpleTableTypes
-    .map((t) => {
-      assertObjectType(t);
-      // I don't know why this has to be cast here, but not 6 lines up.
-      const objType: GraphQLObjectType = t as GraphQLObjectType;
-
-      return [
-        `export interface ResultType<T> {
+  const content = `export interface ResultType<T> {
   capacity: ConsumedCapacity;
   item: T;
   metrics: ItemCollectionMetrics | undefined;
-}`,
-        createItemTemplate(objType),
-        deleteItemTemplate(objType),
-        readItemTemplate(objType),
-        touchItemTemplate(objType),
-        updateItemTemplate(objType),
-      ].join('\n\n');
-    })
-    .join('\n');
+}
+
+${simpleTableTypes
+  .map((t) => {
+    assertObjectType(t);
+    // I don't know why this has to be cast here, but not 6 lines up.
+    const objType: GraphQLObjectType = t as GraphQLObjectType;
+
+    return [
+      `export interface ${objType.name}PrimaryKey {
+        id: Scalars['ID'];
+      }`,
+      createItemTemplate(objType),
+      deleteItemTemplate(objType),
+      readItemTemplate(objType),
+      touchItemTemplate(objType),
+      updateItemTemplate(objType),
+    ].join('\n\n');
+  })
+  .join('\n')}`;
 
   assert(info?.outputFile, 'info.outputFile is required');
 

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -18,6 +18,7 @@ export function createItemTemplate(objType: GraphQLObjectType) {
 
   const ean: string[] = [];
   const eav: string[] = [];
+  const key: string[] = [`id: \`${objType.name}#\${uuidv4()}\``];
   const unmarshall: string[] = [];
   const updateExpressions: string[] = [];
 
@@ -70,6 +71,7 @@ export function createItemTemplate(objType: GraphQLObjectType) {
   return createItemTpl({
     ean,
     eav,
+    key,
     objType,
     ttlInfo,
     unmarshall,
@@ -81,7 +83,9 @@ export function createItemTemplate(objType: GraphQLObjectType) {
  * Generates the deleteItem function for a table
  */
 export function deleteItemTemplate(objType: GraphQLObjectType) {
-  return deleteItemTpl({objType});
+  const ean: string[] = [`'#id': 'id'`];
+  const key = [`id: primaryKey.id`];
+  return deleteItemTpl({ean, key, objType});
 }
 
 /**
@@ -91,6 +95,7 @@ export function readItemTemplate(objType: GraphQLObjectType) {
   const ttlInfo = extractTtlInfo(objType);
   const consistent = hasDirective('consistent', objType);
 
+  const key = [`id: primaryKey.id`];
   const unmarshall: string[] = [];
 
   const fields = objType.getFields();
@@ -116,7 +121,7 @@ export function readItemTemplate(objType: GraphQLObjectType) {
 
   unmarshall.sort();
 
-  return readItemTpl({consistent, objType, unmarshall});
+  return readItemTpl({consistent, key, objType, unmarshall});
 }
 
 /**
@@ -127,6 +132,7 @@ export function touchItemTemplate(objType: GraphQLObjectType) {
 
   const ean: string[] = [];
   const eav: string[] = [];
+  const key: string[] = [`id: primaryKey.id`];
   const updateExpressions: string[] = [];
 
   const fieldNames = Object.keys(objType.getFields()).sort();
@@ -149,7 +155,7 @@ export function touchItemTemplate(objType: GraphQLObjectType) {
   eav.sort();
   updateExpressions.sort();
 
-  return touchItemTpl({ean, eav, objType, updateExpressions});
+  return touchItemTpl({ean, eav, key, objType, updateExpressions});
 }
 
 /**
@@ -160,6 +166,8 @@ export function updateItemTemplate(objType: GraphQLObjectType) {
 
   const ean: string[] = [];
   const eav: string[] = [];
+  const inputToPrimaryKey = [`id: input.id`];
+  const key: string[] = [`id: input.id`];
   const unmarshall: string[] = [];
   const updateExpressions: string[] = [];
 
@@ -208,6 +216,8 @@ export function updateItemTemplate(objType: GraphQLObjectType) {
   return updateItemTpl({
     ean,
     eav,
+    inputToPrimaryKey,
+    key,
     objType,
     ttlInfo,
     unmarshall,

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -11,7 +11,7 @@ import {touchItemTpl} from './templates/touch-item';
 import {updateItemTpl} from './templates/update-item';
 
 /**
- * Generates the createItem function for a simple table
+ * Generates the createItem function for a table
  */
 export function createItemTemplate(objType: GraphQLObjectType) {
   const ttlInfo = extractTtlInfo(objType);
@@ -78,14 +78,14 @@ export function createItemTemplate(objType: GraphQLObjectType) {
 }
 
 /**
- * Generates the deleteItem function for a simple table
+ * Generates the deleteItem function for a table
  */
 export function deleteItemTemplate(objType: GraphQLObjectType) {
   return deleteItemTpl({objType});
 }
 
 /**
- * Generates the readItem function for a simple table
+ * Generates the readItem function for a table
  */
 export function readItemTemplate(objType: GraphQLObjectType) {
   const ttlInfo = extractTtlInfo(objType);
@@ -120,7 +120,7 @@ export function readItemTemplate(objType: GraphQLObjectType) {
 }
 
 /**
- * Generates the updateItem function for a simple table
+ * Generates the updateItem function for a table
  */
 export function touchItemTemplate(objType: GraphQLObjectType) {
   const ttlInfo = extractTtlInfo(objType);
@@ -153,7 +153,7 @@ export function touchItemTemplate(objType: GraphQLObjectType) {
 }
 
 /**
- * Generates the updateItem function for a simple table
+ * Generates the updateItem function for a table
  */
 export function updateItemTemplate(objType: GraphQLObjectType) {
   const ttlInfo = extractTtlInfo(objType);

--- a/src/codegen/actions/tables/templates/create-item.ts
+++ b/src/codegen/actions/tables/templates/create-item.ts
@@ -10,6 +10,7 @@ export interface CreateItemTplInput {
   readonly ttlInfo: Nullable<TtlInfo>;
   readonly ean: readonly string[];
   readonly eav: readonly string[];
+  readonly key: readonly string[];
   readonly unmarshall: readonly string[];
   readonly updateExpressions: readonly string[];
 }
@@ -19,6 +20,7 @@ export function createItemTpl({
   ttlInfo,
   ean,
   eav,
+  key,
   unmarshall,
   updateExpressions,
 }: CreateItemTplInput) {
@@ -53,7 +55,7 @@ ${ean.map((e) => `        ${e},`).join('\n')}
 ${eav.map((e) => `        ${e},`).join('\n')}
       },
       Key: {
-        id: \`${typeName}#\${uuidv4()}\`,
+${key.map((k) => `        ${k},`).join('\n')}
       },
       ReturnConsumedCapacity: 'INDEXES',
       ReturnItemCollectionMetrics: 'SIZE',

--- a/src/codegen/actions/tables/templates/delete-item.ts
+++ b/src/codegen/actions/tables/templates/delete-item.ts
@@ -3,32 +3,35 @@ import {GraphQLObjectType} from 'graphql';
 import {ensureTableTemplate} from './ensure-table';
 
 export interface DeleteItemTplInput {
+  readonly ean: readonly string[];
+  readonly key: readonly string[];
   readonly objType: GraphQLObjectType;
 }
 
 /** template */
-export function deleteItemTpl({objType}: DeleteItemTplInput) {
+export function deleteItemTpl({ean, key, objType}: DeleteItemTplInput) {
   const typeName = objType.name;
 
   const inputTypeName = `Delete${typeName}Input`;
   const outputTypeName = `Delete${typeName}Output`;
+  const primaryKeyType = `${objType.name}PrimaryKey`;
 
   return `
 export type ${inputTypeName} = Scalars['ID'];
 export type ${outputTypeName} = ResultType<void>;
 
 /**  */
-export async function delete${typeName}(id: ${inputTypeName}): Promise<${outputTypeName}> {
+export async function delete${typeName}(primaryKey: ${primaryKeyType}): Promise<${outputTypeName}> {
 ${ensureTableTemplate(objType)}
 
   try {
     const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} = await ddbDocClient.send(new DeleteCommand({
       ConditionExpression: 'attribute_exists(#id)',
       ExpressionAttributeNames: {
-        '#id': 'id',
+${ean.map((e) => `        ${e},`).join('\n')}
       },
       Key: {
-        id,
+${key.map((k) => `        ${k},`).join('\n')}
       },
       ReturnConsumedCapacity: 'INDEXES',
       ReturnItemCollectionMetrics: 'SIZE',
@@ -46,7 +49,7 @@ ${ensureTableTemplate(objType)}
   }
   catch (err) {
     if (err instanceof ConditionalCheckFailedException) {
-      throw new NotFoundError('${typeName}', id);
+      throw new NotFoundError('${typeName}', primaryKey);
     }
     throw err;
   }

--- a/src/codegen/actions/tables/templates/ensure-table.ts
+++ b/src/codegen/actions/tables/templates/ensure-table.ts
@@ -1,4 +1,4 @@
-import {GraphQLObjectType} from 'graphql/index';
+import {GraphQLObjectType} from 'graphql';
 import {snakeCase} from 'lodash';
 
 /**

--- a/src/codegen/cloudformation/plugin.ts
+++ b/src/codegen/cloudformation/plugin.ts
@@ -5,8 +5,10 @@ import {
   AddToSchemaResult,
   PluginFunction,
 } from '@graphql-codegen/plugin-helpers';
-import {assertObjectType} from 'graphql';
+import {assertObjectType, isObjectType} from 'graphql';
 import {snakeCase} from 'lodash';
+
+import {hasInterface} from '../common/helpers';
 
 import {CloudformationPluginConfig} from './config';
 
@@ -22,16 +24,7 @@ export const plugin: PluginFunction<CloudformationPluginConfig> = (schema) => {
   const simpleTableTypes = Object.keys(typesMap)
     .filter((typeName) => {
       const type = typesMap[typeName];
-      const {astNode} = type;
-
-      if (
-        astNode?.kind === 'ObjectTypeDefinition' &&
-        astNode.interfaces?.map(({name}) => name.value).includes('SimpleModel')
-      ) {
-        return true;
-      }
-
-      return false;
+      return isObjectType(type) && hasInterface('SimpleModel', type);
     })
     .map((typeName) => {
       const objType = typesMap[typeName];

--- a/src/codegen/common/fields.ts
+++ b/src/codegen/common/fields.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import {GraphQLObjectType} from 'graphql/index';
+import {GraphQLObjectType} from 'graphql';
 
 import {Nullable} from '../../types';
 

--- a/src/codegen/common/helpers.ts
+++ b/src/codegen/common/helpers.ts
@@ -16,6 +16,16 @@ export function hasDirective(
     .includes(directiveName);
 }
 
+/** Indicates if objType implements the specified interface */
+export function hasInterface(
+  interfaceName: string,
+  objType: GraphQLObjectType
+) {
+  return !!objType.astNode?.interfaces
+    ?.map(({name}) => name.value)
+    .includes(interfaceName);
+}
+
 /**
  * Indicates if field is the specified type. Does not care if field is NonNull
  */

--- a/src/codegen/schema.graphqls
+++ b/src/codegen/schema.graphqls
@@ -23,17 +23,36 @@ entities that all might use different names
 directive @ttl(duration: String!) on FIELD_DEFINITION
 
 """
-SimpleModels are DynamoDB with a key schema that does not include a sort key.
+Automatically adds a createdAt and updatedAt timestamp to the entity and sets
+them appropriately. The createdAt timestamp is only set on create, while the
+updatedAt timestamp is set on create and update.
 """
-interface SimpleModel {
+interface Timestamped {
   """
   Set automatically when the item is first written
   """
   createdAt: Date!
-  id: ID!
   """
   Set automatically when the item is updated
   """
+  updatedAt: Date!
+}
+
+"""
+Automatically adds a column to enable optimistic locking. This field shouldn't
+be manipulated directly, but may need to be passed around by the runtime in
+order to make updates.
+"""
+interface Versioned {
+  version: Int!
+}
+
+"""
+SimpleModels are DynamoDB with a key schema that does not include a sort key.
+"""
+interface SimpleModel implements Timestamped & Versioned {
+  createdAt: Date!
+  id: ID!
   updatedAt: Date!
   version: Int!
 }

--- a/src/lib/not-found-error.ts
+++ b/src/lib/not-found-error.ts
@@ -1,7 +1,7 @@
-/** Thrown when the requested item cannot befound */
-export class NotFoundError extends Error {
+/** Thrown when the requested item cannot be found */
+export class NotFoundError<PK extends object> extends Error {
   /** constructor */
-  constructor(typeName: string, id: string) {
-    super(`No ${typeName} found with id ${id}`);
+  constructor(typeName: string, primaryKey: PK) {
+    super(`No ${typeName} found with id ${JSON.stringify(primaryKey)}`);
   }
 }

--- a/src/lib/optimistic-locking-error.ts
+++ b/src/lib/optimistic-locking-error.ts
@@ -2,11 +2,13 @@
  * Thrown when the requested item is out of date. use readUserSession to ge the
  * latest version
  */
-export class OptimisticLockingError extends Error {
+export class OptimisticLockingError<PK extends object> extends Error {
   /** constructor */
-  constructor(typeName: string, id: string) {
+  constructor(typeName: string, primaryKey: PK) {
     super(
-      `${typeName} with id ${id} is out of date. Please refresh and try again.`
+      `${typeName} with id ${JSON.stringify(
+        primaryKey
+      )} is out of date. Please refresh and try again.`
     );
   }
 }


### PR DESCRIPTION
- refactor: cleanup filters
- refactor: shorten imports
- feat: introduce more Versioned and Timestamped
- refactor: tweek test names so they can be reused in each new example
- refactor: rename simple-table to table
- feat: compute primary key type
