### PR TITLE
updates

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/cache@v3.0.6
+      - uses: actions/cache@v3.0.11
         env:
           cache-name: cache-node-modules
         with:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/cache@v3.0.6
+      - uses: actions/cache@v3.0.11
         env:
           cache-name: cache-node-modules
         with:
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3.0.6
+      - uses: actions/cache@v3.0.11
         env:
           cache-name: cache-node-modules
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/jest": "^29.2.0",
         "@types/lodash": "^4.14.187",
         "@types/node": "^18",
-        "@typescript-eslint/eslint-plugin": "^5.41.0",
+        "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
         "aws-xray-sdk-core": "^3.4.0",
         "eslint": "^8.26.0",
@@ -6539,14 +6539,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.0.tgz",
-      "integrity": "sha512-QrZqaIOzJAjv0sfjY4EjbXUi3ZOFpKfzntx22gPGr9pmFcTjcFw/1sS1LJhEubfAGwuLjNrPV0rH+D1/XZFy7Q==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz",
+      "integrity": "sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.46.0",
-        "@typescript-eslint/type-utils": "5.46.0",
-        "@typescript-eslint/utils": "5.46.0",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/type-utils": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -6569,6 +6569,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+      "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
@@ -6702,31 +6749,14 @@
         "node": ">=10"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.0.tgz",
-      "integrity": "sha512-7wWBq9d/GbPiIM6SqPK9tfynNxVbfpihoY5cSFMer19OYUA3l4powA2uv0AV2eAZV6KoAh6lkzxv4PoxOLh1oA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/visitor-keys": "5.46.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.0.tgz",
-      "integrity": "sha512-dwv4nimVIAsVS2dTA0MekkWaRnoYNXY26dKz8AN5W3cBFYwYGFQEqm/cG+TOoooKlncJS4RTbFKgcFY/pOiBCg==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz",
+      "integrity": "sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.46.0",
-        "@typescript-eslint/utils": "5.46.0",
+        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -6746,10 +6776,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.0.tgz",
-      "integrity": "sha512-wHWgQHFB+qh6bu0IAPAJCdeCdI0wwzZnnWThlmHNY01XJ9Z97oKqKOzWYpR2I83QmshhQJl6LDM9TqMiMwJBTw==",
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6759,14 +6789,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.0.tgz",
-      "integrity": "sha512-kDLNn/tQP+Yp8Ro2dUpyyVV0Ksn2rmpPpB0/3MO874RNmXtypMwSeazjEN/Q6CTp8D7ExXAAekPEcCEB/vtJkw==",
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+      "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/visitor-keys": "5.46.0",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6786,7 +6816,24 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
@@ -6802,16 +6849,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.0.tgz",
-      "integrity": "sha512-4O+Ps1CRDw+D+R40JYh5GlKLQERXRKW5yIQoNDpmXPJ+C7kaPF9R7GWl+PxGgXjB3PQCqsaaZUpZ9dG4U6DO7g==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.1.tgz",
+      "integrity": "sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.46.0",
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/typescript-estree": "5.46.0",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -6827,6 +6874,80 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+      "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+      "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -6840,23 +6961,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.0.tgz",
-      "integrity": "sha512-E13gBoIXmaNhwjipuvQg1ByqSAu/GbEpP/qzFihugJ+MomtoJtFAJG/+2DRPByf57B863m0/q7Zt16V9ohhANw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.46.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@whatwg-node/fetch": {
@@ -24786,8 +24890,8 @@
         "@types/jest": "^29.2.0",
         "@types/lodash": "^4.14.187",
         "@types/node": "^18",
-        "@typescript-eslint/eslint-plugin": "^5.41.0",
-        "@typescript-eslint/parser": "5.46.1",
+        "@typescript-eslint/eslint-plugin": "^5.46.1",
+        "@typescript-eslint/parser": "^5.46.1",
         "aws-xray-sdk-core": "^3.4.0",
         "base64url": "^3.0.1",
         "eslint": "^8.26.0",
@@ -29827,14 +29931,14 @@
           "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.0.tgz",
-          "integrity": "sha512-QrZqaIOzJAjv0sfjY4EjbXUi3ZOFpKfzntx22gPGr9pmFcTjcFw/1sS1LJhEubfAGwuLjNrPV0rH+D1/XZFy7Q==",
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz",
+          "integrity": "sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "5.46.0",
-            "@typescript-eslint/type-utils": "5.46.0",
-            "@typescript-eslint/utils": "5.46.0",
+            "@typescript-eslint/scope-manager": "5.46.1",
+            "@typescript-eslint/type-utils": "5.46.1",
+            "@typescript-eslint/utils": "5.46.1",
             "debug": "^4.3.4",
             "ignore": "^5.2.0",
             "natural-compare-lite": "^1.4.0",
@@ -29843,6 +29947,32 @@
             "tsutils": "^3.21.0"
           },
           "dependencies": {
+            "@typescript-eslint/scope-manager": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+              "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "@typescript-eslint/visitor-keys": "5.46.1"
+              }
+            },
+            "@typescript-eslint/types": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+              "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+              "dev": true
+            },
+            "@typescript-eslint/visitor-keys": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+              "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "eslint-visitor-keys": "^3.3.0"
+              }
+            },
             "semver": {
               "version": "7.3.8",
               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -29918,49 +30048,49 @@
             }
           }
         },
-        "@typescript-eslint/scope-manager": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.0.tgz",
-          "integrity": "sha512-7wWBq9d/GbPiIM6SqPK9tfynNxVbfpihoY5cSFMer19OYUA3l4powA2uv0AV2eAZV6KoAh6lkzxv4PoxOLh1oA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.46.0",
-            "@typescript-eslint/visitor-keys": "5.46.0"
-          }
-        },
         "@typescript-eslint/type-utils": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.0.tgz",
-          "integrity": "sha512-dwv4nimVIAsVS2dTA0MekkWaRnoYNXY26dKz8AN5W3cBFYwYGFQEqm/cG+TOoooKlncJS4RTbFKgcFY/pOiBCg==",
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz",
+          "integrity": "sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/typescript-estree": "5.46.0",
-            "@typescript-eslint/utils": "5.46.0",
+            "@typescript-eslint/typescript-estree": "5.46.1",
+            "@typescript-eslint/utils": "5.46.1",
             "debug": "^4.3.4",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.0.tgz",
-          "integrity": "sha512-wHWgQHFB+qh6bu0IAPAJCdeCdI0wwzZnnWThlmHNY01XJ9Z97oKqKOzWYpR2I83QmshhQJl6LDM9TqMiMwJBTw==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.0.tgz",
-          "integrity": "sha512-kDLNn/tQP+Yp8Ro2dUpyyVV0Ksn2rmpPpB0/3MO874RNmXtypMwSeazjEN/Q6CTp8D7ExXAAekPEcCEB/vtJkw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.46.0",
-            "@typescript-eslint/visitor-keys": "5.46.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
             "tsutils": "^3.21.0"
           },
           "dependencies": {
+            "@typescript-eslint/types": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+              "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+              "dev": true
+            },
+            "@typescript-eslint/typescript-estree": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+              "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "@typescript-eslint/visitor-keys": "5.46.1",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+              }
+            },
+            "@typescript-eslint/visitor-keys": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+              "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "eslint-visitor-keys": "^3.3.0"
+              }
+            },
             "semver": {
               "version": "7.3.8",
               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -29973,21 +30103,62 @@
           }
         },
         "@typescript-eslint/utils": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.0.tgz",
-          "integrity": "sha512-4O+Ps1CRDw+D+R40JYh5GlKLQERXRKW5yIQoNDpmXPJ+C7kaPF9R7GWl+PxGgXjB3PQCqsaaZUpZ9dG4U6DO7g==",
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.1.tgz",
+          "integrity": "sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.9",
             "@types/semver": "^7.3.12",
-            "@typescript-eslint/scope-manager": "5.46.0",
-            "@typescript-eslint/types": "5.46.0",
-            "@typescript-eslint/typescript-estree": "5.46.0",
+            "@typescript-eslint/scope-manager": "5.46.1",
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/typescript-estree": "5.46.1",
             "eslint-scope": "^5.1.1",
             "eslint-utils": "^3.0.0",
             "semver": "^7.3.7"
           },
           "dependencies": {
+            "@typescript-eslint/scope-manager": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+              "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "@typescript-eslint/visitor-keys": "5.46.1"
+              }
+            },
+            "@typescript-eslint/types": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+              "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+              "dev": true
+            },
+            "@typescript-eslint/typescript-estree": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+              "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "@typescript-eslint/visitor-keys": "5.46.1",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+              }
+            },
+            "@typescript-eslint/visitor-keys": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+              "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "eslint-visitor-keys": "^3.3.0"
+              }
+            },
             "semver": {
               "version": "7.3.8",
               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -29997,16 +30168,6 @@
                 "lru-cache": "^6.0.0"
               }
             }
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.0.tgz",
-          "integrity": "sha512-E13gBoIXmaNhwjipuvQg1ByqSAu/GbEpP/qzFihugJ+MomtoJtFAJG/+2DRPByf57B863m0/q7Zt16V9ohhANw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.46.0",
-            "eslint-visitor-keys": "^3.3.0"
           }
         },
         "@whatwg-node/fetch": {
@@ -41787,14 +41948,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.0.tgz",
-      "integrity": "sha512-QrZqaIOzJAjv0sfjY4EjbXUi3ZOFpKfzntx22gPGr9pmFcTjcFw/1sS1LJhEubfAGwuLjNrPV0rH+D1/XZFy7Q==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz",
+      "integrity": "sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.46.0",
-        "@typescript-eslint/type-utils": "5.46.0",
-        "@typescript-eslint/utils": "5.46.0",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/type-utils": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -41803,6 +41964,32 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+          "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/visitor-keys": "5.46.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+          "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+          "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -41878,49 +42065,49 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.0.tgz",
-      "integrity": "sha512-7wWBq9d/GbPiIM6SqPK9tfynNxVbfpihoY5cSFMer19OYUA3l4powA2uv0AV2eAZV6KoAh6lkzxv4PoxOLh1oA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/visitor-keys": "5.46.0"
-      }
-    },
     "@typescript-eslint/type-utils": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.0.tgz",
-      "integrity": "sha512-dwv4nimVIAsVS2dTA0MekkWaRnoYNXY26dKz8AN5W3cBFYwYGFQEqm/cG+TOoooKlncJS4RTbFKgcFY/pOiBCg==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz",
+      "integrity": "sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.46.0",
-        "@typescript-eslint/utils": "5.46.0",
+        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.0.tgz",
-      "integrity": "sha512-wHWgQHFB+qh6bu0IAPAJCdeCdI0wwzZnnWThlmHNY01XJ9Z97oKqKOzWYpR2I83QmshhQJl6LDM9TqMiMwJBTw==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.0.tgz",
-      "integrity": "sha512-kDLNn/tQP+Yp8Ro2dUpyyVV0Ksn2rmpPpB0/3MO874RNmXtypMwSeazjEN/Q6CTp8D7ExXAAekPEcCEB/vtJkw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/visitor-keys": "5.46.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "@typescript-eslint/types": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+          "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+          "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/visitor-keys": "5.46.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+          "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -41933,21 +42120,62 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.0.tgz",
-      "integrity": "sha512-4O+Ps1CRDw+D+R40JYh5GlKLQERXRKW5yIQoNDpmXPJ+C7kaPF9R7GWl+PxGgXjB3PQCqsaaZUpZ9dG4U6DO7g==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.1.tgz",
+      "integrity": "sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.46.0",
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/typescript-estree": "5.46.0",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+          "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/visitor-keys": "5.46.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+          "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+          "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/visitor-keys": "5.46.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+          "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -41957,16 +42185,6 @@
             "lru-cache": "^6.0.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.0.tgz",
-      "integrity": "sha512-E13gBoIXmaNhwjipuvQg1ByqSAu/GbEpP/qzFihugJ+MomtoJtFAJG/+2DRPByf57B863m0/q7Zt16V9ohhANw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.46.0",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@whatwg-node/fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6467,9 +6467,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
+      "version": "18.11.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.16.tgz",
+      "integrity": "sha512-6T7P5bDkRhqRxrQtwj7vru+bWTpelgtcETAZEUSdq0YISKz8WKdoBukQLYQQ6DFHvU9JRsbFq0JH5C51X2ZdnA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -29859,9 +29859,9 @@
           "dev": true
         },
         "@types/node": {
-          "version": "18.11.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-          "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
+          "version": "18.11.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.16.tgz",
+          "integrity": "sha512-6T7P5bDkRhqRxrQtwj7vru+bWTpelgtcETAZEUSdq0YISKz8WKdoBukQLYQQ6DFHvU9JRsbFq0JH5C51X2ZdnA==",
           "dev": true
         },
         "@types/normalize-package-data": {
@@ -41876,9 +41876,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
+      "version": "18.11.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.16.tgz",
+      "integrity": "sha512-6T7P5bDkRhqRxrQtwj7vru+bWTpelgtcETAZEUSdq0YISKz8WKdoBukQLYQQ6DFHvU9JRsbFq0JH5C51X2ZdnA==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/lodash": "^4.14.187",
         "@types/node": "^18",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
-        "@typescript-eslint/parser": "^5.41.0",
+        "@typescript-eslint/parser": "^5.46.1",
         "aws-xray-sdk-core": "^3.4.0",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
@@ -6587,14 +6587,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.0.tgz",
-      "integrity": "sha512-joNO6zMGUZg+C73vwrKXCd8usnsmOYmgW/w5ZW0pG0RGvqeznjtGDk61EqqTpNrFLUYBW2RSBFrxdAZMqA4OZA==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.1.tgz",
+      "integrity": "sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.46.0",
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/typescript-estree": "5.46.0",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6611,6 +6611,95 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+      "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+      "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.46.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -24698,7 +24787,7 @@
         "@types/lodash": "^4.14.187",
         "@types/node": "^18",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
-        "@typescript-eslint/parser": "^5.41.0",
+        "@typescript-eslint/parser": "5.46.1",
         "aws-xray-sdk-core": "^3.4.0",
         "base64url": "^3.0.1",
         "eslint": "^8.26.0",
@@ -29766,15 +29855,67 @@
           }
         },
         "@typescript-eslint/parser": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.0.tgz",
-          "integrity": "sha512-joNO6zMGUZg+C73vwrKXCd8usnsmOYmgW/w5ZW0pG0RGvqeznjtGDk61EqqTpNrFLUYBW2RSBFrxdAZMqA4OZA==",
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.1.tgz",
+          "integrity": "sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "5.46.0",
-            "@typescript-eslint/types": "5.46.0",
-            "@typescript-eslint/typescript-estree": "5.46.0",
+            "@typescript-eslint/scope-manager": "5.46.1",
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/typescript-estree": "5.46.1",
             "debug": "^4.3.4"
+          },
+          "dependencies": {
+            "@typescript-eslint/scope-manager": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+              "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "@typescript-eslint/visitor-keys": "5.46.1"
+              }
+            },
+            "@typescript-eslint/types": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+              "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+              "dev": true
+            },
+            "@typescript-eslint/typescript-estree": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+              "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "@typescript-eslint/visitor-keys": "5.46.1",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+              }
+            },
+            "@typescript-eslint/visitor-keys": {
+              "version": "5.46.1",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+              "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/types": "5.46.1",
+                "eslint-visitor-keys": "^3.3.0"
+              }
+            },
+            "semver": {
+              "version": "7.3.8",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+              "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
           }
         },
         "@typescript-eslint/scope-manager": {
@@ -41674,15 +41815,67 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.0.tgz",
-      "integrity": "sha512-joNO6zMGUZg+C73vwrKXCd8usnsmOYmgW/w5ZW0pG0RGvqeznjtGDk61EqqTpNrFLUYBW2RSBFrxdAZMqA4OZA==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.1.tgz",
+      "integrity": "sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.46.0",
-        "@typescript-eslint/types": "5.46.0",
-        "@typescript-eslint/typescript-estree": "5.46.0",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+          "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/visitor-keys": "5.46.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+          "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+          "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "@typescript-eslint/visitor-keys": "5.46.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.46.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+          "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.46.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24686,7 +24686,7 @@
         "@commitlint/config-conventional": "^17.1.0",
         "@faker-js/faker": "^7.6.0",
         "@graphql-codegen/cli": "^2.13.8",
-        "@graphql-codegen/plugin-helpers": "3.1.1",
+        "@graphql-codegen/plugin-helpers": "^3.1.1",
         "@graphql-codegen/typescript": "^2.8.0",
         "@graphql-eslint/eslint-plugin": "^3.12.0",
         "@ianwremmel/data": "file:",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "^29.2.0",
     "@types/lodash": "^4.14.187",
     "@types/node": "^18",
-    "@typescript-eslint/eslint-plugin": "^5.41.0",
+    "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
     "aws-xray-sdk-core": "^3.4.0",
     "eslint": "^8.26.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/lodash": "^4.14.187",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
-    "@typescript-eslint/parser": "^5.41.0",
+    "@typescript-eslint/parser": "^5.46.1",
     "aws-xray-sdk-core": "^3.4.0",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
- chore(deps-dev): bump @typescript-eslint/eslint-plugin
- chore(deps-dev): bump @typescript-eslint/parser from 5.41.0 to 5.46.1
- chore(deps): bump actions/cache from 3.0.6 to 3.0.11
- chore(deps): update lockfile
- chore(deps-dev): bump @types/node from 18.11.13 to 18.11.16
