### PR TITLE
fix localstack

### DIFF
--- a/examples/change-data-capture/change-data-capture.test.ts
+++ b/examples/change-data-capture/change-data-capture.test.ts
@@ -14,7 +14,7 @@ describe('Change Date Capture', () => {
   // some part of the eventbridge setup doesn't work in localstack. This means
   // there's no test for this in CI right now, but it works when tested locally
   // against a real AWS account, which I don't want to wire into CI right now.
-  (process.env.TEST_MODE === 'localstack' ? it.skip : it)(
+  it(
     'applies a custom mapper to update one model based on another',
     async () => {
       const externalId = String(faker.datatype.number());

--- a/scripts/deploy-examples-to-localstack
+++ b/scripts/deploy-examples-to-localstack
@@ -4,7 +4,7 @@ set -euo pipefail
 pip3 install --upgrade pyopenssl
 pip3 install localstack awscli-local[ver1] aws-sam-cli-local
 docker pull localstack/localstack
-localstack start -d
+PROVIDER_OVERRIDE_LAMBDA=asf localstack start -d
 
 echo "Waiting for LocalStack startup..."
 localstack wait -t 30

--- a/src/runtime/functions/table-dispatcher/make-table-dispatcher.ts
+++ b/src/runtime/functions/table-dispatcher/make-table-dispatcher.ts
@@ -20,6 +20,8 @@ async function handleRecord(
   batchItemFailures: string[]
 ) {
   try {
+    const modelName = record.dynamodb?.NewImage?._et.S;
+
     await eventBridge.send(
       new PutEventsCommand({
         Entries: [
@@ -29,7 +31,7 @@ async function handleRecord(
             Resources: record.eventSourceARN
               ? [record.eventSourceARN.split('/stream')[0]]
               : [],
-            Source: `${tableName}`,
+            Source: [tableName, modelName].join('.'),
             Time: record.dynamodb?.ApproximateCreationDateTime
               ? new Date(record.dynamodb.ApproximateCreationDateTime)
               : undefined,


### PR DESCRIPTION
- fix(actions): fix event pattern for CDC dispatcher
- test: reenable test which does not currently work in localstack
- fix(examples): infer AWS_ENDPOINT for localstack more effectively
- ci: use PROVIDER_OVERRIDE_LAMBDA=asf to support node18 in localstack
