### PR TITLE
ttl and blind update

### DIFF
--- a/examples/change-data-capture/change-data-capture.test.ts
+++ b/examples/change-data-capture/change-data-capture.test.ts
@@ -14,7 +14,7 @@ describe('Change Date Capture', () => {
   // some part of the eventbridge setup doesn't work in localstack. This means
   // there's no test for this in CI right now, but it works when tested locally
   // against a real AWS account, which I don't want to wire into CI right now.
-  (process.env.TEST_MODE === 'localstack' ? it.skip : it)(
+  it(
     'applies a custom mapper to update one model based on another',
     async () => {
       const externalId = String(faker.datatype.number());

--- a/examples/real-world-complex-cdc/__generated__/actions.ts
+++ b/examples/real-world-complex-cdc/__generated__/actions.ts
@@ -257,6 +257,72 @@ export async function createCaseInstance(
   };
 }
 
+export type BlindWriteCaseInstanceInput = Omit<
+  CaseInstance,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type BlindWriteCaseInstanceOutput = ResultType<CaseInstance>;
+/** */
+export async function blindWriteCaseInstance(
+  input: Readonly<BlindWriteCaseInstanceInput>
+): Promise<Readonly<BlindWriteCaseInstanceOutput>> {
+  const tableName = process.env.TABLE_CASE_INSTANCE;
+  assert(tableName, 'TABLE_CASE_INSTANCE is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallCaseInstance(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {
+        pk: `CASE#${input.vendor}#${input.repoId}#${input.branchName}#${input.label}#${input.lineage}`,
+        sk: `INSTANCE#${input.sha}#${input.retry}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'CaseInstance',
+    () =>
+      new DataIntegrityError(
+        `Expected to write CaseInstance but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallCaseInstance(item),
+    metrics,
+  };
+}
+
 export type DeleteCaseInstanceOutput = ResultType<void>;
 
 /**  */
@@ -1115,6 +1181,72 @@ export async function createCaseSummary(
   };
 }
 
+export type BlindWriteCaseSummaryInput = Omit<
+  CaseSummary,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type BlindWriteCaseSummaryOutput = ResultType<CaseSummary>;
+/** */
+export async function blindWriteCaseSummary(
+  input: Readonly<BlindWriteCaseSummaryInput>
+): Promise<Readonly<BlindWriteCaseSummaryOutput>> {
+  const tableName = process.env.TABLE_CASE_SUMMARY;
+  assert(tableName, 'TABLE_CASE_SUMMARY is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallCaseSummary(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {
+        pk: `CASE#${input.vendor}#${input.repoId}#${input.branchName}#${input.label}#${input.lineage}`,
+        sk: `SUMMARY`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'CaseSummary',
+    () =>
+      new DataIntegrityError(
+        `Expected to write CaseSummary but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallCaseSummary(item),
+    metrics,
+  };
+}
+
 export type DeleteCaseSummaryOutput = ResultType<void>;
 
 /**  */
@@ -1788,6 +1920,72 @@ export async function createFileTiming(
       ReturnValues: 'ALL_NEW',
       TableName: tableName,
       UpdateExpression,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'FileTiming',
+    () =>
+      new DataIntegrityError(
+        `Expected to write FileTiming but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallFileTiming(item),
+    metrics,
+  };
+}
+
+export type BlindWriteFileTimingInput = Omit<
+  FileTiming,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type BlindWriteFileTimingOutput = ResultType<FileTiming>;
+/** */
+export async function blindWriteFileTiming(
+  input: Readonly<BlindWriteFileTimingInput>
+): Promise<Readonly<BlindWriteFileTimingOutput>> {
+  const tableName = process.env.TABLE_FILE_TIMING;
+  assert(tableName, 'TABLE_FILE_TIMING is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallFileTiming(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {
+        pk: `TIMING#${input.vendor}#${input.repoId}#${input.branchName}#${input.label}`,
+        sk: `FILE#${input.filename}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
     })
   );
 

--- a/examples/schema-directives/__generated__/actions.ts
+++ b/examples/schema-directives/__generated__/actions.ts
@@ -151,7 +151,7 @@ export interface UserSessionPrimaryKey {
 export type CreateUserSessionInput = Omit<
   UserSession,
   'createdAt' | 'expires' | 'id' | 'updatedAt' | 'version'
->;
+> & {expires?: Date};
 export type CreateUserSessionOutput = ResultType<UserSession>;
 /**  */
 export async function createUserSession(
@@ -342,7 +342,7 @@ export async function touchUserSession(
 export type UpdateUserSessionInput = Omit<
   UserSession,
   'createdAt' | 'expires' | 'id' | 'updatedAt'
->;
+> & {expires?: Date};
 export type UpdateUserSessionOutput = ResultType<UserSession>;
 
 /**  */
@@ -451,7 +451,8 @@ export function marshallUserSession(
   const eav: Record<string, unknown> = {
     ':entity': 'UserSession',
     ':createdAt': now.getTime(),
-    ':expires': now.getTime() + 86400000,
+    ':expires':
+      'expires' in input ? input.expires.getTime() : now.getTime() + 86400000,
     ':session': input.session,
     ':sessionId': input.sessionId,
     ':updatedAt': now.getTime(),

--- a/examples/schema-directives/__generated__/actions.ts
+++ b/examples/schema-directives/__generated__/actions.ts
@@ -205,6 +205,69 @@ export async function createUserSession(
   };
 }
 
+export type BlindWriteUserSessionInput = Omit<
+  UserSession,
+  'createdAt' | 'expires' | 'id' | 'updatedAt' | 'version'
+> & {expires?: Date};
+export type BlindWriteUserSessionOutput = ResultType<UserSession>;
+/** */
+export async function blindWriteUserSession(
+  input: Readonly<BlindWriteUserSessionInput>
+): Promise<Readonly<BlindWriteUserSessionOutput>> {
+  const tableName = process.env.TABLE_USER_SESSIONS;
+  assert(tableName, 'TABLE_USER_SESSIONS is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallUserSession(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {pk: `USER_SESSION#${input.sessionId}`},
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'UserSession',
+    () =>
+      new DataIntegrityError(
+        `Expected to write UserSession but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallUserSession(item),
+    metrics,
+  };
+}
+
 export type DeleteUserSessionOutput = ResultType<void>;
 
 /**  */

--- a/examples/user-session/__generated__/actions.ts
+++ b/examples/user-session/__generated__/actions.ts
@@ -199,6 +199,69 @@ export async function createUserSession(
   };
 }
 
+export type BlindWriteUserSessionInput = Omit<
+  UserSession,
+  'createdAt' | 'expires' | 'id' | 'updatedAt' | 'version'
+> & {expires?: Date};
+export type BlindWriteUserSessionOutput = ResultType<UserSession>;
+/** */
+export async function blindWriteUserSession(
+  input: Readonly<BlindWriteUserSessionInput>
+): Promise<Readonly<BlindWriteUserSessionOutput>> {
+  const tableName = process.env.TABLE_USER_SESSION;
+  assert(tableName, 'TABLE_USER_SESSION is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallUserSession(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {pk: `USER_SESSION#${input.sessionId}`},
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'UserSession',
+    () =>
+      new DataIntegrityError(
+        `Expected to write UserSession but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallUserSession(item),
+    metrics,
+  };
+}
+
 export type DeleteUserSessionOutput = ResultType<void>;
 
 /**  */

--- a/examples/user-session/__generated__/actions.ts
+++ b/examples/user-session/__generated__/actions.ts
@@ -145,7 +145,7 @@ export interface UserSessionPrimaryKey {
 export type CreateUserSessionInput = Omit<
   UserSession,
   'createdAt' | 'expires' | 'id' | 'updatedAt' | 'version'
->;
+> & {expires?: Date};
 export type CreateUserSessionOutput = ResultType<UserSession>;
 /**  */
 export async function createUserSession(
@@ -336,7 +336,7 @@ export async function touchUserSession(
 export type UpdateUserSessionInput = Omit<
   UserSession,
   'createdAt' | 'expires' | 'id' | 'updatedAt'
->;
+> & {expires?: Date};
 export type UpdateUserSessionOutput = ResultType<UserSession>;
 
 /**  */
@@ -445,7 +445,8 @@ export function marshallUserSession(
   const eav: Record<string, unknown> = {
     ':entity': 'UserSession',
     ':createdAt': now.getTime(),
-    ':expires': now.getTime() + 86400000,
+    ':expires':
+      'expires' in input ? input.expires.getTime() : now.getTime() + 86400000,
     ':session': input.session,
     ':sessionId': input.sessionId,
     ':updatedAt': now.getTime(),

--- a/examples/user-session/user-session.test.ts
+++ b/examples/user-session/user-session.test.ts
@@ -1,8 +1,12 @@
+import {GetCommand, QueryCommand, ScanCommand} from '@aws-sdk/lib-dynamodb';
 import {faker} from '@faker-js/faker';
 import {NotFoundError, OptimisticLockingError} from '@ianwremmel/data';
 import Base64 from 'base64url';
 
+import {ddbDocClient} from '../dependencies';
+
 import {
+  blindWriteUserSession,
   createUserSession,
   deleteUserSession,
   readUserSession,
@@ -88,6 +92,229 @@ describe('createUserSession()', () => {
 
     // cleanup, not part of test
     await deleteUserSession(result.item);
+  });
+});
+
+describe('blindWriteUserSession()', () => {
+  it('creates a user session if it does not exist', async () => {
+    const result = await blindWriteUserSession({
+      session: {foo: 'foo'},
+      sessionId: faker.datatype.uuid(),
+    });
+
+    expect(result).toMatchInlineSnapshot(
+      itemMatcher,
+      `
+      {
+        "capacity": {
+          "CapacityUnits": 1,
+          "GlobalSecondaryIndexes": undefined,
+          "LocalSecondaryIndexes": undefined,
+          "ReadCapacityUnits": undefined,
+          "Table": {
+            "CapacityUnits": 1,
+            "ReadCapacityUnits": undefined,
+            "WriteCapacityUnits": undefined,
+          },
+          "TableName": Any<String>,
+          "WriteCapacityUnits": undefined,
+        },
+        "item": {
+          "createdAt": Any<Date>,
+          "expires": Any<Date>,
+          "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+          "session": {
+            "foo": "foo",
+          },
+          "sessionId": "181c887c-e7df-4331-9fba-65d255867e20",
+          "updatedAt": Any<Date>,
+          "version": 1,
+        },
+        "metrics": undefined,
+      }
+    `
+    );
+
+    expect(Base64.decode(result.item.id)).toMatchInlineSnapshot(
+      `"UserSession:USER_SESSION#181c887c-e7df-4331-9fba-65d255867e20"`
+    );
+
+    expect(result.item.createdAt.getTime()).not.toBeNaN();
+    expect(result.item.expires.getTime()).not.toBeNaN();
+    expect(result.item.updatedAt.getTime()).not.toBeNaN();
+    expect(result.item.version).toBe(1);
+
+    // cleanup, not part of test
+    await deleteUserSession(result.item);
+  });
+
+  it('creates a user session with a custom expiration date if it does not exist', async () => {
+    const expires = new Date(Date.now() + 3 * 60 * 60 * 1000);
+
+    const result = await blindWriteUserSession({
+      expires,
+      session: {foo: 'foo'},
+      sessionId: faker.datatype.uuid(),
+    });
+
+    expect(result.item.expires.getTime()).not.toBeNaN();
+
+    expect(result.item.expires).toStrictEqual(expires);
+    expect(result.item.version).toBe(1);
+
+    // cleanup, not part of test
+    await deleteUserSession(result.item);
+  });
+
+  it('overwrites an existing record', async () => {
+    const createResult = await createUserSession({
+      session: {foo: 'foo'},
+      sessionId: faker.datatype.uuid(),
+    });
+    expect(createResult).toMatchInlineSnapshot(
+      itemMatcher,
+      `
+      {
+        "capacity": {
+          "CapacityUnits": 1,
+          "GlobalSecondaryIndexes": undefined,
+          "LocalSecondaryIndexes": undefined,
+          "ReadCapacityUnits": undefined,
+          "Table": {
+            "CapacityUnits": 1,
+            "ReadCapacityUnits": undefined,
+            "WriteCapacityUnits": undefined,
+          },
+          "TableName": Any<String>,
+          "WriteCapacityUnits": undefined,
+        },
+        "item": {
+          "createdAt": Any<Date>,
+          "expires": Any<Date>,
+          "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+          "session": {
+            "foo": "foo",
+          },
+          "sessionId": "181c887c-e7df-4331-9fba-65d255867e20",
+          "updatedAt": Any<Date>,
+          "version": 1,
+        },
+        "metrics": undefined,
+      }
+    `
+    );
+    expect(createResult.item.session).toEqual({foo: 'foo'});
+    expect(createResult.item.version).toBe(1);
+
+    const item = {...createResult.item};
+    // @ts-expect-error
+    delete item.version;
+    const updateResult = await blindWriteUserSession({
+      ...item,
+      session: {foo: 'bar'},
+    });
+    expect(updateResult).toMatchInlineSnapshot(
+      itemMatcher,
+      `
+      {
+        "capacity": {
+          "CapacityUnits": 1,
+          "GlobalSecondaryIndexes": undefined,
+          "LocalSecondaryIndexes": undefined,
+          "ReadCapacityUnits": undefined,
+          "Table": {
+            "CapacityUnits": 1,
+            "ReadCapacityUnits": undefined,
+            "WriteCapacityUnits": undefined,
+          },
+          "TableName": Any<String>,
+          "WriteCapacityUnits": undefined,
+        },
+        "item": {
+          "createdAt": Any<Date>,
+          "expires": Any<Date>,
+          "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+          "session": {
+            "foo": "bar",
+          },
+          "sessionId": "181c887c-e7df-4331-9fba-65d255867e20",
+          "updatedAt": Any<Date>,
+          "version": 2,
+        },
+        "metrics": undefined,
+      }
+    `
+    );
+    expect(updateResult.item.session).toEqual({foo: 'bar'});
+    expect(updateResult.item.version).toBe(2);
+
+    const readResult = await readUserSession(createResult.item);
+    expect(readResult).toMatchInlineSnapshot(
+      itemMatcher,
+      `
+      {
+        "capacity": {
+          "CapacityUnits": 1,
+          "GlobalSecondaryIndexes": undefined,
+          "LocalSecondaryIndexes": undefined,
+          "ReadCapacityUnits": undefined,
+          "Table": {
+            "CapacityUnits": 1,
+            "ReadCapacityUnits": undefined,
+            "WriteCapacityUnits": undefined,
+          },
+          "TableName": Any<String>,
+          "WriteCapacityUnits": undefined,
+        },
+        "item": {
+          "createdAt": Any<Date>,
+          "expires": Any<Date>,
+          "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+          "session": {
+            "foo": "bar",
+          },
+          "sessionId": "181c887c-e7df-4331-9fba-65d255867e20",
+          "updatedAt": Any<Date>,
+          "version": 2,
+        },
+        "metrics": undefined,
+      }
+    `
+    );
+    expect(updateResult.item.session).toEqual({foo: 'bar'});
+
+    expect(readResult.item.createdAt).toEqual(updateResult.item.createdAt);
+    expect(readResult.item.updatedAt).toEqual(updateResult.item.updatedAt);
+
+    // cleanup, not part of test
+    await deleteUserSession(createResult.item);
+  });
+
+  it('overwrites an existing record with a custom expiration Date', async () => {
+    const expires = new Date(Date.now() + 3 * 60 * 60 * 1000);
+
+    const createResult = await createUserSession({
+      session: {foo: 'foo'},
+      sessionId: faker.datatype.uuid(),
+    });
+
+    expect(createResult.item.expires).not.toBe(expires);
+    expect(createResult.item.version).toBe(1);
+
+    const updateResult = await blindWriteUserSession({
+      ...createResult.item,
+      expires,
+      session: {foo: 'bar'},
+    });
+
+    expect(updateResult.item.expires).toStrictEqual(expires);
+    expect(updateResult.item.version).toBe(2);
+
+    const readResult = await readUserSession(createResult.item);
+    expect(readResult.item.expires).toStrictEqual(expires);
+
+    // cleanup, not part of test
+    await deleteUserSession(createResult.item);
   });
 });
 

--- a/examples/user-session/user-session.test.ts
+++ b/examples/user-session/user-session.test.ts
@@ -72,6 +72,23 @@ describe('createUserSession()', () => {
     // cleanup, not part of test
     await deleteUserSession(result.item);
   });
+
+  it('creates a record with a custom expiration Date', async () => {
+    const expires = new Date(Date.now() + 3 * 60 * 60 * 1000);
+
+    const result = await createUserSession({
+      expires,
+      session: {foo: 'foo'},
+      sessionId: faker.datatype.uuid(),
+    });
+
+    expect(result.item.expires.getTime()).not.toBeNaN();
+
+    expect(result.item.expires).toStrictEqual(expires);
+
+    // cleanup, not part of test
+    await deleteUserSession(result.item);
+  });
 });
 
 describe('deleteUserSession()', () => {
@@ -376,6 +393,31 @@ describe('updateUserSession()', () => {
 
     expect(readResult.item.createdAt).toEqual(updateResult.item.createdAt);
     expect(readResult.item.updatedAt).toEqual(updateResult.item.updatedAt);
+
+    // cleanup, not part of test
+    await deleteUserSession(createResult.item);
+  });
+
+  it('updates a record with a custom expiration Date', async () => {
+    const expires = new Date(Date.now() + 3 * 60 * 60 * 1000);
+
+    const createResult = await createUserSession({
+      session: {foo: 'foo'},
+      sessionId: faker.datatype.uuid(),
+    });
+
+    expect(createResult.item.expires).not.toBe(expires);
+
+    const updateResult = await updateUserSession({
+      ...createResult.item,
+      expires,
+      session: {foo: 'bar'},
+    });
+
+    expect(updateResult.item.expires).toStrictEqual(expires);
+
+    const readResult = await readUserSession(createResult.item);
+    expect(readResult.item.expires).toStrictEqual(expires);
 
     // cleanup, not part of test
     await deleteUserSession(createResult.item);

--- a/jest.d/global-setup/stack-env.ts
+++ b/jest.d/global-setup/stack-env.ts
@@ -13,6 +13,7 @@ import {camelCase, snakeCase, upperFirst} from 'lodash';
  * Loads stack outputs as environment variables
  */
 export default async function loadAwsEnv() {
+  process.env.TEST_MODE = process.env.TEST_MODE ?? 'localstack';
   if (process.env.TEST_MODE === 'localstack') {
     // Set fake credentials for localstack
     process.env.AWS_ACCESS_KEY_ID = 'test';

--- a/scripts/deploy-examples-to-localstack
+++ b/scripts/deploy-examples-to-localstack
@@ -4,7 +4,7 @@ set -euo pipefail
 pip3 install --upgrade pyopenssl
 pip3 install localstack awscli-local[ver1] aws-sam-cli-local
 docker pull localstack/localstack
-localstack start -d
+PROVIDER_OVERRIDE_LAMBDA=asf localstack start -d
 
 echo "Waiting for LocalStack startup..."
 localstack wait -t 30

--- a/src/codegen/actions/plugin.ts
+++ b/src/codegen/actions/plugin.ts
@@ -11,6 +11,7 @@ import {parse} from '../parser';
 
 import type {ActionPluginConfig} from './config';
 import {
+  blindWriteTemplate,
   createItemTemplate,
   deleteItemTemplate,
   queryTemplate,
@@ -66,6 +67,7 @@ ${parse(schema, documents, config, info)
         )
       )}`,
       createItemTemplate(table),
+      blindWriteTemplate(table),
       deleteItemTemplate(table),
       readItemTemplate(table),
       touchItemTemplate(table),

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -1,5 +1,6 @@
 import type {PrimaryKeyConfig, Table} from '../../parser';
 
+import {blindWriteTpl} from './templates/blind-write';
 import {createItemTpl} from './templates/create-item';
 import {deleteItemTpl} from './templates/delete-item';
 import {makeKeyTemplate, objectToString} from './templates/helpers';
@@ -15,6 +16,18 @@ export function createItemTemplate(irTable: Table) {
   return createItemTpl({
     key: makeKey(irTable.primaryKey),
     omit: ['id', irTable.ttlConfig?.fieldName ?? ''].filter(Boolean),
+    tableName: irTable.tableName,
+    ttlConfig: irTable.ttlConfig,
+    typeName: irTable.typeName,
+  });
+}
+
+/**
+ * Generates the createItem function for a table
+ */
+export function blindWriteTemplate(irTable: Table) {
+  return blindWriteTpl({
+    key: makeKey(irTable.primaryKey),
     tableName: irTable.tableName,
     ttlConfig: irTable.ttlConfig,
     typeName: irTable.typeName,

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -16,6 +16,7 @@ export function createItemTemplate(irTable: Table) {
     key: makeKey(irTable.primaryKey),
     omit: ['id', irTable.ttlConfig?.fieldName ?? ''].filter(Boolean),
     tableName: irTable.tableName,
+    ttlConfig: irTable.ttlConfig,
     typeName: irTable.typeName,
   });
 }
@@ -119,7 +120,7 @@ export function updateItemTemplate(irTable: Table) {
       )
     ),
     tableName: irTable.tableName,
-    ttlInfo: irTable.ttlConfig,
+    ttlConfig: irTable.ttlConfig,
     typeName: irTable.typeName,
   });
 }

--- a/src/codegen/actions/tables/templates/blind-write.ts
+++ b/src/codegen/actions/tables/templates/blind-write.ts
@@ -1,0 +1,74 @@
+import type {TTLConfig} from '../../../parser';
+
+import {ensureTableTemplate} from './ensure-table';
+import {objectToString} from './helpers';
+
+export interface BlindWriteTplInput {
+  readonly key: Record<string, string>;
+  readonly tableName: string;
+  readonly ttlConfig: TTLConfig | undefined;
+  readonly typeName: string;
+}
+
+/** template */
+export function blindWriteTpl({
+  key,
+  tableName,
+  ttlConfig,
+  typeName,
+}: BlindWriteTplInput) {
+  const inputTypeName = `BlindWrite${typeName}Input`;
+  const omitInputFields = [
+    'id',
+    'createdAt',
+    'updatedAt',
+    'version',
+    ...(ttlConfig ? [ttlConfig.fieldName] : []),
+  ]
+    .map((f) => `'${f}'`)
+    .sort();
+  const outputTypeName = `BlindWrite${typeName}Output`;
+
+  return `
+export type ${inputTypeName} = Omit<${typeName}, ${omitInputFields.join(
+    '|'
+  )}> ${ttlConfig ? ` & {${ttlConfig.fieldName}?: Date}` : ''};
+export type ${outputTypeName} = ResultType<${typeName}>;
+/** */
+export async function blindWrite${typeName}(input: Readonly<${inputTypeName}>): Promise<Readonly<${outputTypeName}>> {
+${ensureTableTemplate(tableName)}
+  const {ExpressionAttributeNames, ExpressionAttributeValues, UpdateExpression} = marshall${typeName}(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = UpdateExpression
+    .split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ') + ' ADD #version :one'
+
+  const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics, Attributes: item} = await ddbDocClient.send(new UpdateCommand({
+    ExpressionAttributeNames,
+    ExpressionAttributeValues: eav,
+    Key: ${objectToString(key)},
+    ReturnConsumedCapacity: 'INDEXES',
+    ReturnItemCollectionMetrics: 'SIZE',
+    ReturnValues: 'ALL_NEW',
+    TableName: tableName,
+    UpdateExpression: ue,
+  }));
+
+  assert(capacity, 'Expected ConsumedCapacity to be returned. This is a bug in codegen.');
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(item._et === '${typeName}', () => new DataIntegrityError(\`Expected to write ${typeName} but wrote \${item?._et} instead\`));
+
+  return {
+    capacity,
+    item: unmarshall${typeName}(item),
+    metrics,
+  }
+}
+`;
+}

--- a/src/codegen/actions/tables/templates/create-item.ts
+++ b/src/codegen/actions/tables/templates/create-item.ts
@@ -1,3 +1,5 @@
+import type {TTLConfig} from '../../../parser';
+
 import {ensureTableTemplate} from './ensure-table';
 import {objectToString} from './helpers';
 
@@ -5,11 +7,13 @@ export interface CreateItemTplInput {
   readonly key: Record<string, string>;
   readonly omit: readonly string[];
   readonly tableName: string;
+  readonly ttlConfig: TTLConfig | undefined;
   readonly typeName: string;
 }
 
 /** template */
 export function createItemTpl({
+  ttlConfig,
   key,
   tableName,
   typeName,
@@ -22,7 +26,9 @@ export function createItemTpl({
   const outputTypeName = `Create${typeName}Output`;
 
   return `
-export type ${inputTypeName} = Omit<${typeName}, ${omitInputFields.join('|')}>;
+export type ${inputTypeName} = Omit<${typeName}, ${omitInputFields.join('|')}>${
+    ttlConfig ? ` & {${ttlConfig.fieldName}?: Date}` : ''
+  };
 export type ${outputTypeName} = ResultType<${typeName}>
 /**  */
 export async function create${typeName}(input: Readonly<Create${typeName}Input>): Promise<Readonly<${outputTypeName}>> {

--- a/src/codegen/actions/tables/templates/marshall.ts
+++ b/src/codegen/actions/tables/templates/marshall.ts
@@ -65,7 +65,10 @@ ${secondaryIndexes
           return `':version': ('version' in input ? input.version : 0) + 1,`;
         }
         if (fieldName === ttlConfig?.fieldName) {
-          return `':${fieldName}': now.getTime() + ${ttlConfig.duration},`;
+          return `':${fieldName}': '${fieldName}' in input ? ${marshalField(
+            fieldName,
+            isDateType
+          )} : now.getTime() + ${ttlConfig.duration},`;
         }
         if (fieldName === 'createdAt') {
           return `':${fieldName}': now.getTime(),`;

--- a/src/codegen/actions/tables/templates/update-item.ts
+++ b/src/codegen/actions/tables/templates/update-item.ts
@@ -7,7 +7,7 @@ export interface UpdateItemTplInput {
   readonly key: Record<string, string>;
   readonly marshallPrimaryKey: string;
   readonly tableName: string;
-  readonly ttlInfo: TTLConfig | undefined;
+  readonly ttlConfig: TTLConfig | undefined;
   readonly typeName: string;
 }
 
@@ -16,7 +16,7 @@ export function updateItemTpl({
   marshallPrimaryKey,
   key,
   tableName,
-  ttlInfo,
+  ttlConfig,
   typeName,
 }: UpdateItemTplInput) {
   const inputTypeName = `Update${typeName}Input`;
@@ -24,14 +24,16 @@ export function updateItemTpl({
     'id',
     'createdAt',
     'updatedAt',
-    ...(ttlInfo ? [ttlInfo.fieldName] : []),
+    ...(ttlConfig ? [ttlConfig.fieldName] : []),
   ]
     .map((f) => `'${f}'`)
     .sort();
   const outputTypeName = `Update${typeName}Output`;
 
   return `
-export type ${inputTypeName} = Omit<${typeName}, ${omitInputFields.join('|')}>;
+export type ${inputTypeName} = Omit<${typeName}, ${omitInputFields.join(
+    '|'
+  )}> ${ttlConfig ? ` & {${ttlConfig.fieldName}?: Date}` : ''};
 export type ${outputTypeName} = ResultType<${typeName}>
 
 /**  */

--- a/src/runtime/functions/table-dispatcher/make-table-dispatcher.ts
+++ b/src/runtime/functions/table-dispatcher/make-table-dispatcher.ts
@@ -20,6 +20,8 @@ async function handleRecord(
   batchItemFailures: string[]
 ) {
   try {
+    const modelName = record.dynamodb?.NewImage?._et.S;
+
     await eventBridge.send(
       new PutEventsCommand({
         Entries: [
@@ -29,7 +31,7 @@ async function handleRecord(
             Resources: record.eventSourceARN
               ? [record.eventSourceARN.split('/stream')[0]]
               : [],
-            Source: `${tableName}`,
+            Source: [tableName, modelName].join('.'),
             Time: record.dynamodb?.ApproximateCreationDateTime
               ? new Date(record.dynamodb.ApproximateCreationDateTime)
               : undefined,


### PR DESCRIPTION
- fix(actions): fix event pattern for CDC dispatcher
- test: reenable test which does not currently work in localstack
- fix(examples): infer AWS_ENDPOINT for localstack more effectively
- ci: use PROVIDER_OVERRIDE_LAMBDA=asf to support node18 in localstack
- ci: default to testing in localstack
- feat(actions): allow passing explicit ttl
- feat: add blindWrite()
