### PR TITLE
single table design

### DIFF
--- a/examples/change-data-capture/__generated__/template.yml
+++ b/examples/change-data-capture/__generated__/template.yml
@@ -147,7 +147,11 @@ Resources:
           Projection:
             ProjectionType: ALL
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:
@@ -175,7 +179,11 @@ Resources:
         - AttributeName: sk
           KeyType: RANGE
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:

--- a/examples/existing-json-template/__generated__/template.yml
+++ b/examples/existing-json-template/__generated__/template.yml
@@ -64,7 +64,11 @@ Resources:
         - AttributeName: sk
           KeyType: RANGE
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:

--- a/examples/existing-yml-schema/__generated__/template.yml
+++ b/examples/existing-yml-schema/__generated__/template.yml
@@ -72,7 +72,11 @@ Resources:
         - AttributeName: sk
           KeyType: RANGE
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:

--- a/examples/real-world-complex-cdc/__generated__/template.yml
+++ b/examples/real-world-complex-cdc/__generated__/template.yml
@@ -117,7 +117,11 @@ Resources:
           Projection:
             ProjectionType: ALL
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:
@@ -166,7 +170,11 @@ Resources:
           Projection:
             ProjectionType: ALL
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:
@@ -218,7 +226,11 @@ Resources:
           Projection:
             ProjectionType: ALL
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:

--- a/examples/schema-directives/__generated__/actions.ts
+++ b/examples/schema-directives/__generated__/actions.ts
@@ -164,11 +164,14 @@ export async function createUserSession(
 ): Promise<Readonly<CreateUserSessionOutput>> {
   const tableName = process.env.TABLE_USER_SESSIONS;
   assert(tableName, 'TABLE_USER_SESSIONS is not set');
+
+  const now = new Date();
+
   const {
     ExpressionAttributeNames,
     ExpressionAttributeValues,
     UpdateExpression,
-  } = marshallUserSession(input);
+  } = marshallUserSession(input, now);
   // Reminder: we use UpdateCommand rather than PutCommand because PutCommand
   // cannot return the newly written values.
   const {
@@ -178,14 +181,20 @@ export async function createUserSession(
   } = await ddbDocClient.send(
     new UpdateCommand({
       ConditionExpression: 'attribute_not_exists(#pk)',
-      ExpressionAttributeNames,
-      ExpressionAttributeValues,
+      ExpressionAttributeNames: {
+        ...ExpressionAttributeNames,
+        '#createdAt': '_ct',
+      },
+      ExpressionAttributeValues: {
+        ...ExpressionAttributeValues,
+        ':createdAt': now.getTime(),
+      },
       Key: {pk: `USER_SESSION#${input.sessionId}`},
       ReturnConsumedCapacity: 'INDEXES',
       ReturnItemCollectionMetrics: 'SIZE',
       ReturnValues: 'ALL_NEW',
       TableName: tableName,
-      UpdateExpression,
+      UpdateExpression: `${UpdateExpression}, #createdAt = :createdAt`,
     })
   );
 
@@ -222,19 +231,29 @@ export async function blindWriteUserSession(
 ): Promise<Readonly<BlindWriteUserSessionOutput>> {
   const tableName = process.env.TABLE_USER_SESSIONS;
   assert(tableName, 'TABLE_USER_SESSIONS is not set');
+  const now = new Date();
   const {
     ExpressionAttributeNames,
     ExpressionAttributeValues,
     UpdateExpression,
-  } = marshallUserSession(input);
+  } = marshallUserSession(input, now);
 
   delete ExpressionAttributeNames['#pk'];
   delete ExpressionAttributeValues[':version'];
 
-  const eav = {...ExpressionAttributeValues, ':one': 1};
-  const ue = `${UpdateExpression.split(', ')
-    .filter((e) => !e.startsWith('#version'))
-    .join(', ')} ADD #version :one`;
+  const ean = {
+    ...ExpressionAttributeNames,
+    '#createdAt': '_ct',
+  };
+  const eav = {
+    ...ExpressionAttributeValues,
+    ':one': 1,
+    ':createdAt': now.getTime(),
+  };
+  const ue = `${[
+    ...UpdateExpression.split(', ').filter((e) => !e.startsWith('#version')),
+    '#createdAt = if_not_exists(#createdAt, :createdAt)',
+  ].join(', ')} ADD #version :one`;
 
   const {
     ConsumedCapacity: capacity,
@@ -242,7 +261,7 @@ export async function blindWriteUserSession(
     Attributes: item,
   } = await ddbDocClient.send(
     new UpdateCommand({
-      ExpressionAttributeNames,
+      ExpressionAttributeNames: ean,
       ExpressionAttributeValues: eav,
       Key: {pk: `USER_SESSION#${input.sessionId}`},
       ReturnConsumedCapacity: 'INDEXES',
@@ -506,13 +525,11 @@ export type MarshallUserSessionInput = Required<
 
 /** Marshalls a DynamoDB record into a UserSession object */
 export function marshallUserSession(
-  input: MarshallUserSessionInput
+  input: MarshallUserSessionInput,
+  now = new Date()
 ): MarshallUserSessionOutput {
-  const now = new Date();
-
   const updateExpression: string[] = [
     '#entity = :entity',
-    '#createdAt = :createdAt',
     '#session = :session',
     '#sessionId = :sessionId',
     '#updatedAt = :updatedAt',
@@ -522,7 +539,6 @@ export function marshallUserSession(
   const ean: Record<string, string> = {
     '#entity': '_et',
     '#pk': 'pk',
-    '#createdAt': '_ct',
     '#session': 'session',
     '#sessionId': 'session_id',
     '#updatedAt': '_md',
@@ -533,7 +549,6 @@ export function marshallUserSession(
     ':entity': 'UserSession',
     ':session': input.session,
     ':sessionId': input.sessionId,
-    ':createdAt': now.getTime(),
     ':updatedAt': now.getTime(),
     ':version': ('version' in input ? input.version ?? 0 : 0) + 1,
   };

--- a/examples/schema-directives/schema/user-session.graphqls
+++ b/examples/schema-directives/schema/user-session.graphqls
@@ -22,4 +22,6 @@ type UserSession implements Model & Node & Timestamped & Versioned
   when an optional field is absent from the payload.
   """
   optionalField: String
+
+  aliasedField: String @alias(name: "renamedField")
 }

--- a/examples/single-table-design/__generated__/actions.ts
+++ b/examples/single-table-design/__generated__/actions.ts
@@ -1,0 +1,1506 @@
+import type {
+  ConsumedCapacity,
+  ItemCollectionMetrics,
+} from '@aws-sdk/client-dynamodb';
+import {ConditionalCheckFailedException} from '@aws-sdk/client-dynamodb';
+import {
+  DeleteCommand,
+  GetCommand,
+  QueryCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {ServiceException} from '@aws-sdk/smithy-client';
+import type {NativeAttributeValue} from '@aws-sdk/util-dynamodb/dist-types/models';
+import {
+  assert,
+  DataIntegrityError,
+  NotFoundError,
+  OptimisticLockingError,
+  UnexpectedAwsError,
+  UnexpectedError,
+} from '@ianwremmel/data';
+import Base64 from 'base64url';
+
+import {ddbDocClient} from '../../dependencies';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends {[key: string]: unknown}> = {[K in keyof T]: T[K]};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export interface QueryOptions {
+  limit?: number;
+  /**
+   * All operators supported by DynamoDB are except `between`. `between` is
+   * not supported because it requires two values and that makes the codegen
+   * quite a bit more tedious. If it's needed, please open a ticket and we can
+   * look into adding it.
+   */
+  operator?: 'begins_with' | '=' | '<' | '<=' | '>' | '>=';
+  reverse?: boolean;
+}
+/** All built-in and custom scalars, mapped to their actual values */
+export interface Scalars {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  /** JavaScript Date stored as a Number in DynamoDB */
+  Date: Date;
+  /** Arbitrary JSON stored as a Map in DynamoDB */
+  JSONObject: Record<string, unknown>;
+}
+
+/** An object to track a user's logins */
+export type Account = Model &
+  Node &
+  Timestamped &
+  Versioned & {
+    __typename?: 'Account';
+    cancelled?: Maybe<Scalars['Boolean']>;
+    createdAt: Scalars['Date'];
+    effectiveDate: Scalars['Date'];
+    externalId: Scalars['String'];
+    id: Scalars['ID'];
+    onFreeTrial?: Maybe<Scalars['Boolean']>;
+    planName?: Maybe<PlanName>;
+    updatedAt: Scalars['Date'];
+    vendor: Vendor;
+    version: Scalars['Int'];
+  };
+
+/** CDC Event Types */
+export type CdcEvent = 'INSERT' | 'MODIFY' | 'REMOVE' | 'UPSERT';
+
+/**
+ * Models are DynamoDB tables with a key schema that may or may not include a sort
+ * key. A Model must be decorated with either @partitionKey or @compositeKey.
+ *
+ * Note that, while Model does not explicitly implement Node, its `id` field
+ * behaves like `Node#id` typically does. This is to avoid defining Node in the
+ * injected schema if the consumer's schema also defined Node or defines it
+ * differently.
+ */
+export interface Model {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
+/** The Node interface */
+export interface Node {
+  id: Scalars['ID'];
+}
+
+/** The available plans. */
+export type PlanName = 'ENTERPRISE' | 'OPEN_SOURCE' | 'SMALL_TEAM';
+
+/** The Query type */
+export interface Query {
+  __typename?: 'Query';
+  node?: Maybe<Node>;
+}
+
+/** The Query type */
+export interface QueryNodeArgs {
+  id: Scalars['ID'];
+}
+
+/** An object to track a user's logins */
+export type Subscription = Model &
+  Node &
+  Timestamped &
+  Versioned & {
+    __typename?: 'Subscription';
+    cancelled?: Maybe<Scalars['Boolean']>;
+    createdAt: Scalars['Date'];
+    effectiveDate: Scalars['Date'];
+    externalId: Scalars['String'];
+    id: Scalars['ID'];
+    onFreeTrial?: Maybe<Scalars['Boolean']>;
+    planName?: Maybe<PlanName>;
+    updatedAt: Scalars['Date'];
+    vendor: Vendor;
+    version: Scalars['Int'];
+  };
+
+/**
+ * Automatically adds a createdAt and updatedAt timestamp to the entity and sets
+ * them appropriately. The createdAt timestamp is only set on create, while the
+ * updatedAt timestamp is set on create and update.
+ */
+export interface Timestamped {
+  /** Set automatically when the item is first written */
+  createdAt: Scalars['Date'];
+  /** Set automatically when the item is updated */
+  updatedAt: Scalars['Date'];
+}
+
+/** Indicates which third-party this record came from. */
+export type Vendor = 'AZURE_DEV_OPS' | 'GITHUB' | 'GITLAB';
+
+/**
+ * Automatically adds a column to enable optimistic locking. This field shouldn't
+ * be manipulated directly, but may need to be passed around by the runtime in
+ * order to make updates.
+ */
+export interface Versioned {
+  version: Scalars['Int'];
+}
+
+export interface ResultType<T> {
+  capacity: ConsumedCapacity;
+  item: T;
+  metrics: ItemCollectionMetrics | undefined;
+}
+
+export interface MultiResultType<T> {
+  capacity: ConsumedCapacity;
+  items: T[];
+}
+
+export interface AccountPrimaryKey {
+  externalId: Scalars['String'];
+  vendor: Vendor;
+}
+
+export type CreateAccountInput = Omit<
+  Account,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type CreateAccountOutput = ResultType<Account>;
+/**  */
+export async function createAccount(
+  input: Readonly<CreateAccountInput>
+): Promise<Readonly<CreateAccountOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallAccount(input);
+  // Reminder: we use UpdateCommand rather than PutCommand because PutCommand
+  // cannot return the newly written values.
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ConditionExpression: 'attribute_not_exists(#pk)',
+      ExpressionAttributeNames,
+      ExpressionAttributeValues,
+      Key: {pk: `ACCOUNT#${input.vendor}#${input.externalId}`, sk: `SUMMARY`},
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'Account',
+    () =>
+      new DataIntegrityError(
+        `Expected to write Account but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallAccount(item),
+    metrics,
+  };
+}
+
+export type BlindWriteAccountInput = Omit<
+  Account,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type BlindWriteAccountOutput = ResultType<Account>;
+/** */
+export async function blindWriteAccount(
+  input: Readonly<BlindWriteAccountInput>
+): Promise<Readonly<BlindWriteAccountOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallAccount(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {pk: `ACCOUNT#${input.vendor}#${input.externalId}`, sk: `SUMMARY`},
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'Account',
+    () =>
+      new DataIntegrityError(
+        `Expected to write Account but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallAccount(item),
+    metrics,
+  };
+}
+
+export type DeleteAccountOutput = ResultType<void>;
+
+/**  */
+export async function deleteAccount(
+  input: AccountPrimaryKey
+): Promise<DeleteAccountOutput> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new DeleteCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `SUMMARY`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'NONE',
+          TableName: tableName,
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('Account', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type ReadAccountOutput = ResultType<Account>;
+
+/**  */
+export async function readAccount(
+  input: AccountPrimaryKey
+): Promise<Readonly<ReadAccountOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+
+  const {ConsumedCapacity: capacity, Item: item} = await ddbDocClient.send(
+    new GetCommand({
+      ConsistentRead: false,
+      Key: {pk: `ACCOUNT#${input.vendor}#${input.externalId}`, sk: `SUMMARY`},
+      ReturnConsumedCapacity: 'INDEXES',
+      TableName: tableName,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, () => new NotFoundError('Account', input));
+  assert(
+    item._et === 'Account',
+    () =>
+      new DataIntegrityError(
+        `Expected ${JSON.stringify(input)} to load a Account but loaded ${
+          item._et
+        } instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallAccount(item),
+    metrics: undefined,
+  };
+}
+
+export type TouchAccountOutput = ResultType<void>;
+
+/**  */
+export async function touchAccount(
+  input: AccountPrimaryKey
+): Promise<TouchAccountOutput> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new UpdateCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+            '#version': '_v',
+          },
+          ExpressionAttributeValues: {
+            ':versionInc': 1,
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `SUMMARY`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'ALL_NEW',
+          TableName: tableName,
+          UpdateExpression: 'SET #version = #version + :versionInc',
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('Account', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type UpdateAccountInput = Omit<
+  Account,
+  'createdAt' | 'id' | 'updatedAt'
+>;
+export type UpdateAccountOutput = ResultType<Account>;
+
+/**  */
+export async function updateAccount(
+  input: Readonly<UpdateAccountInput>
+): Promise<Readonly<UpdateAccountOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallAccount(input);
+  try {
+    const {
+      Attributes: item,
+      ConsumedCapacity: capacity,
+      ItemCollectionMetrics: metrics,
+    } = await ddbDocClient.send(
+      new UpdateCommand({
+        ConditionExpression:
+          '#version = :previousVersion AND #entity = :entity AND attribute_exists(#pk)',
+        ExpressionAttributeNames,
+        ExpressionAttributeValues: {
+          ...ExpressionAttributeValues,
+          ':previousVersion': input.version,
+        },
+        Key: {pk: `ACCOUNT#${input.vendor}#${input.externalId}`, sk: `SUMMARY`},
+        ReturnConsumedCapacity: 'INDEXES',
+        ReturnItemCollectionMetrics: 'SIZE',
+        ReturnValues: 'ALL_NEW',
+        TableName: tableName,
+        UpdateExpression,
+      })
+    );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+    assert(
+      item._et === 'Account',
+      () =>
+        new DataIntegrityError(
+          `Expected ${JSON.stringify({
+            externalId: input.externalId,
+            vendor: input.vendor,
+          })} to update a Account but updated ${item._et} instead`
+        )
+    );
+
+    return {
+      capacity,
+      item: unmarshallAccount(item),
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      try {
+        await readAccount(input);
+      } catch {
+        throw new NotFoundError('Account', {
+          externalId: input.externalId,
+          vendor: input.vendor,
+        });
+      }
+      throw new OptimisticLockingError('Account', {
+        externalId: input.externalId,
+        vendor: input.vendor,
+      });
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type QueryAccountInput =
+  | {externalId: Scalars['String']; vendor: Vendor}
+  | {index: 'lsi1'; externalId: Scalars['String']; vendor: Vendor}
+  | {
+      index: 'lsi1';
+      createdAt: Scalars['Date'];
+      externalId: Scalars['String'];
+      vendor: Vendor;
+    };
+export type QueryAccountOutput = MultiResultType<Account>;
+
+/** helper */
+function makePartitionKeyForQueryAccount(input: QueryAccountInput): string {
+  if (!('index' in input)) {
+    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+  } else if ('index' in input && input.index === 'lsi1') {
+    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+  }
+
+  throw new Error('Could not construct partition key from input');
+}
+
+/** helper */
+function makeSortKeyForQueryAccount(
+  input: QueryAccountInput
+): string | undefined {
+  if ('index' in input) {
+    if (input.index === 'lsi1') {
+      return ['INSTANCE', 'createdAt' in input && input.createdAt]
+        .filter(Boolean)
+        .join('#');
+    }
+  } else {
+    return ['SUMMARY'].filter(Boolean).join('#');
+  }
+}
+
+/** helper */
+function makeEavPkForQueryAccount(input: QueryAccountInput): string {
+  return 'pk';
+}
+
+/** helper */
+function makeEavSkForQueryAccount(input: QueryAccountInput): string {
+  if ('index' in input) {
+    const lsis = ['lsi1'];
+    if (lsis.includes(input.index)) {
+      return input.index;
+    }
+  }
+  return 'sk';
+}
+
+/** queryAccount */
+export async function queryAccount(
+  input: Readonly<QueryAccountInput>,
+  {
+    limit = undefined,
+    operator = 'begins_with',
+    reverse = false,
+  }: QueryOptions = {}
+): Promise<Readonly<QueryAccountOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+
+  const {ConsumedCapacity: capacity, Items: items = []} =
+    await ddbDocClient.send(
+      new QueryCommand({
+        ConsistentRead: false,
+        ExpressionAttributeNames: {
+          '#pk': makeEavPkForQueryAccount(input),
+          '#sk': makeEavSkForQueryAccount(input),
+        },
+        ExpressionAttributeValues: {
+          ':pk': makePartitionKeyForQueryAccount(input),
+          ':sk': makeSortKeyForQueryAccount(input),
+        },
+        IndexName: 'index' in input ? input.index : undefined,
+        KeyConditionExpression: `#pk = :pk AND ${
+          operator === 'begins_with'
+            ? 'begins_with(#sk, :sk)'
+            : `#sk ${operator} :sk`
+        }`,
+        Limit: limit,
+        ReturnConsumedCapacity: 'INDEXES',
+        ScanIndexForward: !reverse,
+        TableName: tableName,
+      })
+    );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  return {
+    capacity,
+    items: items.map((item) => {
+      assert(item._et === 'Account', () => new DataIntegrityError('TODO'));
+      return unmarshallAccount(item);
+    }),
+  };
+}
+
+/** queries the Account table by primary key using a node id */
+export async function queryAccountByNodeId(
+  id: Scalars['ID']
+): Promise<Readonly<Omit<ResultType<Account>, 'metrics'>>> {
+  const primaryKeyValues = Base64.decode(id)
+    .split(':')
+    .slice(1)
+    .join(':')
+    .split('#');
+
+  const primaryKey: QueryAccountInput = {
+    vendor: primaryKeyValues[1] as Vendor,
+    externalId: primaryKeyValues[2],
+  };
+
+  const {capacity, items} = await queryAccount(primaryKey);
+
+  assert(items.length > 0, () => new NotFoundError('Account', primaryKey));
+  assert(
+    items.length < 2,
+    () => new DataIntegrityError(`Found multiple Account with id ${id}`)
+  );
+
+  return {capacity, item: items[0]};
+}
+
+export interface MarshallAccountOutput {
+  ExpressionAttributeNames: Record<string, string>;
+  ExpressionAttributeValues: Record<string, NativeAttributeValue>;
+  UpdateExpression: string;
+}
+
+export type MarshallAccountInput = Required<
+  Pick<Account, 'effectiveDate' | 'externalId' | 'vendor'>
+> &
+  Partial<Pick<Account, 'cancelled' | 'onFreeTrial' | 'planName' | 'version'>>;
+
+/** Marshalls a DynamoDB record into a Account object */
+export function marshallAccount(
+  input: MarshallAccountInput
+): MarshallAccountOutput {
+  const now = new Date();
+
+  const updateExpression: string[] = [
+    '#entity = :entity',
+    '#createdAt = :createdAt',
+    '#effectiveDate = :effectiveDate',
+    '#externalId = :externalId',
+    '#updatedAt = :updatedAt',
+    '#vendor = :vendor',
+    '#version = :version',
+    '#lsi1sk = :lsi1sk',
+  ];
+
+  const ean: Record<string, string> = {
+    '#entity': '_et',
+    '#pk': 'pk',
+    '#createdAt': '_ct',
+    '#effectiveDate': 'effective_date',
+    '#externalId': 'external_id',
+    '#updatedAt': '_md',
+    '#vendor': 'vendor',
+    '#version': '_v',
+    '#lsi1sk': 'lsi1sk',
+  };
+
+  const eav: Record<string, unknown> = {
+    ':entity': 'Account',
+    ':effectiveDate': input.effectiveDate.getTime(),
+    ':externalId': input.externalId,
+    ':vendor': input.vendor,
+    ':createdAt': now.getTime(),
+    ':updatedAt': now.getTime(),
+    ':version': ('version' in input ? input.version ?? 0 : 0) + 1,
+    ':lsi1sk': `INSTANCE#${now.getTime()}`,
+  };
+
+  if ('cancelled' in input && typeof input.cancelled !== 'undefined') {
+    ean['#cancelled'] = 'cancelled';
+    eav[':cancelled'] = input.cancelled;
+    updateExpression.push('#cancelled = :cancelled');
+  }
+
+  if ('onFreeTrial' in input && typeof input.onFreeTrial !== 'undefined') {
+    ean['#onFreeTrial'] = 'on_free_trial';
+    eav[':onFreeTrial'] = input.onFreeTrial;
+    updateExpression.push('#onFreeTrial = :onFreeTrial');
+  }
+
+  if ('planName' in input && typeof input.planName !== 'undefined') {
+    ean['#planName'] = 'plan_name';
+    eav[':planName'] = input.planName;
+    updateExpression.push('#planName = :planName');
+  }
+  updateExpression.sort();
+
+  return {
+    ExpressionAttributeNames: ean,
+    ExpressionAttributeValues: eav,
+    UpdateExpression: `SET ${updateExpression.join(', ')}`,
+  };
+}
+
+/** Unmarshalls a DynamoDB record into a Account object */
+export function unmarshallAccount(item: Record<string, any>): Account {
+  if ('_ct' in item) {
+    assert(
+      item._ct !== null,
+      () => new DataIntegrityError('Expected createdAt to be non-null')
+    );
+    assert(
+      typeof item._ct !== 'undefined',
+      () => new DataIntegrityError('Expected createdAt to be defined')
+    );
+  }
+  if ('effective_date' in item) {
+    assert(
+      item.effective_date !== null,
+      () => new DataIntegrityError('Expected effectiveDate to be non-null')
+    );
+    assert(
+      typeof item.effective_date !== 'undefined',
+      () => new DataIntegrityError('Expected effectiveDate to be defined')
+    );
+  }
+  if ('external_id' in item) {
+    assert(
+      item.external_id !== null,
+      () => new DataIntegrityError('Expected externalId to be non-null')
+    );
+    assert(
+      typeof item.external_id !== 'undefined',
+      () => new DataIntegrityError('Expected externalId to be defined')
+    );
+  }
+  if ('id' in item) {
+    assert(
+      item.id !== null,
+      () => new DataIntegrityError('Expected id to be non-null')
+    );
+    assert(
+      typeof item.id !== 'undefined',
+      () => new DataIntegrityError('Expected id to be defined')
+    );
+  }
+  if ('_md' in item) {
+    assert(
+      item._md !== null,
+      () => new DataIntegrityError('Expected updatedAt to be non-null')
+    );
+    assert(
+      typeof item._md !== 'undefined',
+      () => new DataIntegrityError('Expected updatedAt to be defined')
+    );
+  }
+  if ('vendor' in item) {
+    assert(
+      item.vendor !== null,
+      () => new DataIntegrityError('Expected vendor to be non-null')
+    );
+    assert(
+      typeof item.vendor !== 'undefined',
+      () => new DataIntegrityError('Expected vendor to be defined')
+    );
+  }
+  if ('_v' in item) {
+    assert(
+      item._v !== null,
+      () => new DataIntegrityError('Expected version to be non-null')
+    );
+    assert(
+      typeof item._v !== 'undefined',
+      () => new DataIntegrityError('Expected version to be defined')
+    );
+  }
+
+  let result: Account = {
+    createdAt: new Date(item._ct),
+    effectiveDate: new Date(item.effective_date),
+    externalId: item.external_id,
+    id: Base64.encode(`Account:${item.pk}#:#${item.sk}`),
+    updatedAt: new Date(item._md),
+    vendor: item.vendor,
+    version: item._v,
+  };
+
+  if ('cancelled' in item) {
+    result = {
+      ...result,
+      cancelled: item.cancelled,
+    };
+  }
+
+  if ('on_free_trial' in item) {
+    result = {
+      ...result,
+      onFreeTrial: item.on_free_trial,
+    };
+  }
+
+  if ('plan_name' in item) {
+    result = {
+      ...result,
+      planName: item.plan_name,
+    };
+  }
+
+  return result;
+}
+
+export interface SubscriptionPrimaryKey {
+  effectiveDate: Scalars['Date'];
+  externalId: Scalars['String'];
+  vendor: Vendor;
+}
+
+export type CreateSubscriptionInput = Omit<
+  Subscription,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type CreateSubscriptionOutput = ResultType<Subscription>;
+/**  */
+export async function createSubscription(
+  input: Readonly<CreateSubscriptionInput>
+): Promise<Readonly<CreateSubscriptionOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallSubscription(input);
+  // Reminder: we use UpdateCommand rather than PutCommand because PutCommand
+  // cannot return the newly written values.
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ConditionExpression: 'attribute_not_exists(#pk)',
+      ExpressionAttributeNames,
+      ExpressionAttributeValues,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `SUBSCRIPTION#${input.effectiveDate.getTime()}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'Subscription',
+    () =>
+      new DataIntegrityError(
+        `Expected to write Subscription but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallSubscription(item),
+    metrics,
+  };
+}
+
+export type BlindWriteSubscriptionInput = Omit<
+  Subscription,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type BlindWriteSubscriptionOutput = ResultType<Subscription>;
+/** */
+export async function blindWriteSubscription(
+  input: Readonly<BlindWriteSubscriptionInput>
+): Promise<Readonly<BlindWriteSubscriptionOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallSubscription(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `SUBSCRIPTION#${input.effectiveDate.getTime()}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'Subscription',
+    () =>
+      new DataIntegrityError(
+        `Expected to write Subscription but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallSubscription(item),
+    metrics,
+  };
+}
+
+export type DeleteSubscriptionOutput = ResultType<void>;
+
+/**  */
+export async function deleteSubscription(
+  input: SubscriptionPrimaryKey
+): Promise<DeleteSubscriptionOutput> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new DeleteCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `SUBSCRIPTION#${input.effectiveDate.getTime()}`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'NONE',
+          TableName: tableName,
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('Subscription', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type ReadSubscriptionOutput = ResultType<Subscription>;
+
+/**  */
+export async function readSubscription(
+  input: SubscriptionPrimaryKey
+): Promise<Readonly<ReadSubscriptionOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+
+  const {ConsumedCapacity: capacity, Item: item} = await ddbDocClient.send(
+    new GetCommand({
+      ConsistentRead: false,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `SUBSCRIPTION#${input.effectiveDate.getTime()}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      TableName: tableName,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, () => new NotFoundError('Subscription', input));
+  assert(
+    item._et === 'Subscription',
+    () =>
+      new DataIntegrityError(
+        `Expected ${JSON.stringify(input)} to load a Subscription but loaded ${
+          item._et
+        } instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallSubscription(item),
+    metrics: undefined,
+  };
+}
+
+export type TouchSubscriptionOutput = ResultType<void>;
+
+/**  */
+export async function touchSubscription(
+  input: SubscriptionPrimaryKey
+): Promise<TouchSubscriptionOutput> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new UpdateCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+            '#version': '_v',
+          },
+          ExpressionAttributeValues: {
+            ':versionInc': 1,
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `SUBSCRIPTION#${input.effectiveDate.getTime()}`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'ALL_NEW',
+          TableName: tableName,
+          UpdateExpression: 'SET #version = #version + :versionInc',
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('Subscription', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type UpdateSubscriptionInput = Omit<
+  Subscription,
+  'createdAt' | 'id' | 'updatedAt'
+>;
+export type UpdateSubscriptionOutput = ResultType<Subscription>;
+
+/**  */
+export async function updateSubscription(
+  input: Readonly<UpdateSubscriptionInput>
+): Promise<Readonly<UpdateSubscriptionOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallSubscription(input);
+  try {
+    const {
+      Attributes: item,
+      ConsumedCapacity: capacity,
+      ItemCollectionMetrics: metrics,
+    } = await ddbDocClient.send(
+      new UpdateCommand({
+        ConditionExpression:
+          '#version = :previousVersion AND #entity = :entity AND attribute_exists(#pk)',
+        ExpressionAttributeNames,
+        ExpressionAttributeValues: {
+          ...ExpressionAttributeValues,
+          ':previousVersion': input.version,
+        },
+        Key: {
+          pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+          sk: `SUBSCRIPTION#${input.effectiveDate.getTime()}`,
+        },
+        ReturnConsumedCapacity: 'INDEXES',
+        ReturnItemCollectionMetrics: 'SIZE',
+        ReturnValues: 'ALL_NEW',
+        TableName: tableName,
+        UpdateExpression,
+      })
+    );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+    assert(
+      item._et === 'Subscription',
+      () =>
+        new DataIntegrityError(
+          `Expected ${JSON.stringify({
+            effectiveDate: input.effectiveDate,
+            externalId: input.externalId,
+            vendor: input.vendor,
+          })} to update a Subscription but updated ${item._et} instead`
+        )
+    );
+
+    return {
+      capacity,
+      item: unmarshallSubscription(item),
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      try {
+        await readSubscription(input);
+      } catch {
+        throw new NotFoundError('Subscription', {
+          effectiveDate: input.effectiveDate,
+          externalId: input.externalId,
+          vendor: input.vendor,
+        });
+      }
+      throw new OptimisticLockingError('Subscription', {
+        effectiveDate: input.effectiveDate,
+        externalId: input.externalId,
+        vendor: input.vendor,
+      });
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type QuerySubscriptionInput =
+  | {externalId: Scalars['String']; vendor: Vendor}
+  | {
+      effectiveDate: Scalars['Date'];
+      externalId: Scalars['String'];
+      vendor: Vendor;
+    };
+export type QuerySubscriptionOutput = MultiResultType<Subscription>;
+
+/** helper */
+function makePartitionKeyForQuerySubscription(
+  input: QuerySubscriptionInput
+): string {
+  if (!('index' in input)) {
+    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+  }
+
+  throw new Error('Could not construct partition key from input');
+}
+
+/** helper */
+function makeSortKeyForQuerySubscription(
+  input: QuerySubscriptionInput
+): string | undefined {
+  return ['SUBSCRIPTION', 'effectiveDate' in input && input.effectiveDate]
+    .filter(Boolean)
+    .join('#');
+}
+
+/** helper */
+function makeEavPkForQuerySubscription(input: QuerySubscriptionInput): string {
+  return 'pk';
+}
+
+/** helper */
+function makeEavSkForQuerySubscription(input: QuerySubscriptionInput): string {
+  return 'sk';
+}
+
+/** querySubscription */
+export async function querySubscription(
+  input: Readonly<QuerySubscriptionInput>,
+  {
+    limit = undefined,
+    operator = 'begins_with',
+    reverse = false,
+  }: QueryOptions = {}
+): Promise<Readonly<QuerySubscriptionOutput>> {
+  const tableName = process.env.TABLE_ACCOUNTS;
+  assert(tableName, 'TABLE_ACCOUNTS is not set');
+
+  const {ConsumedCapacity: capacity, Items: items = []} =
+    await ddbDocClient.send(
+      new QueryCommand({
+        ConsistentRead: false,
+        ExpressionAttributeNames: {
+          '#pk': makeEavPkForQuerySubscription(input),
+          '#sk': makeEavSkForQuerySubscription(input),
+        },
+        ExpressionAttributeValues: {
+          ':pk': makePartitionKeyForQuerySubscription(input),
+          ':sk': makeSortKeyForQuerySubscription(input),
+        },
+        IndexName: undefined,
+        KeyConditionExpression: `#pk = :pk AND ${
+          operator === 'begins_with'
+            ? 'begins_with(#sk, :sk)'
+            : `#sk ${operator} :sk`
+        }`,
+        Limit: limit,
+        ReturnConsumedCapacity: 'INDEXES',
+        ScanIndexForward: !reverse,
+        TableName: tableName,
+      })
+    );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  return {
+    capacity,
+    items: items.map((item) => {
+      assert(item._et === 'Subscription', () => new DataIntegrityError('TODO'));
+      return unmarshallSubscription(item);
+    }),
+  };
+}
+
+/** queries the Subscription table by primary key using a node id */
+export async function querySubscriptionByNodeId(
+  id: Scalars['ID']
+): Promise<Readonly<Omit<ResultType<Subscription>, 'metrics'>>> {
+  const primaryKeyValues = Base64.decode(id)
+    .split(':')
+    .slice(1)
+    .join(':')
+    .split('#');
+
+  const primaryKey: QuerySubscriptionInput = {
+    vendor: primaryKeyValues[1] as Vendor,
+    externalId: primaryKeyValues[2],
+  };
+
+  if (typeof primaryKeyValues[2] !== 'undefined') {
+    // @ts-ignore - TSC will usually see this as an error because it determined
+    // that primaryKey is the no-sort-fields-specified version of the type.
+    primaryKey.effectiveDate = new Date(primaryKeyValues[5]);
+  }
+
+  const {capacity, items} = await querySubscription(primaryKey);
+
+  assert(items.length > 0, () => new NotFoundError('Subscription', primaryKey));
+  assert(
+    items.length < 2,
+    () => new DataIntegrityError(`Found multiple Subscription with id ${id}`)
+  );
+
+  return {capacity, item: items[0]};
+}
+
+export interface MarshallSubscriptionOutput {
+  ExpressionAttributeNames: Record<string, string>;
+  ExpressionAttributeValues: Record<string, NativeAttributeValue>;
+  UpdateExpression: string;
+}
+
+export type MarshallSubscriptionInput = Required<
+  Pick<Subscription, 'effectiveDate' | 'externalId' | 'vendor'>
+> &
+  Partial<
+    Pick<Subscription, 'cancelled' | 'onFreeTrial' | 'planName' | 'version'>
+  >;
+
+/** Marshalls a DynamoDB record into a Subscription object */
+export function marshallSubscription(
+  input: MarshallSubscriptionInput
+): MarshallSubscriptionOutput {
+  const now = new Date();
+
+  const updateExpression: string[] = [
+    '#entity = :entity',
+    '#createdAt = :createdAt',
+    '#effectiveDate = :effectiveDate',
+    '#externalId = :externalId',
+    '#updatedAt = :updatedAt',
+    '#vendor = :vendor',
+    '#version = :version',
+  ];
+
+  const ean: Record<string, string> = {
+    '#entity': '_et',
+    '#pk': 'pk',
+    '#createdAt': '_ct',
+    '#effectiveDate': 'effective_date',
+    '#externalId': 'external_id',
+    '#updatedAt': '_md',
+    '#vendor': 'vendor',
+    '#version': '_v',
+  };
+
+  const eav: Record<string, unknown> = {
+    ':entity': 'Subscription',
+    ':effectiveDate': input.effectiveDate.getTime(),
+    ':externalId': input.externalId,
+    ':vendor': input.vendor,
+    ':createdAt': now.getTime(),
+    ':updatedAt': now.getTime(),
+    ':version': ('version' in input ? input.version ?? 0 : 0) + 1,
+  };
+
+  if ('cancelled' in input && typeof input.cancelled !== 'undefined') {
+    ean['#cancelled'] = 'cancelled';
+    eav[':cancelled'] = input.cancelled;
+    updateExpression.push('#cancelled = :cancelled');
+  }
+
+  if ('onFreeTrial' in input && typeof input.onFreeTrial !== 'undefined') {
+    ean['#onFreeTrial'] = 'on_free_trial';
+    eav[':onFreeTrial'] = input.onFreeTrial;
+    updateExpression.push('#onFreeTrial = :onFreeTrial');
+  }
+
+  if ('planName' in input && typeof input.planName !== 'undefined') {
+    ean['#planName'] = 'plan_name';
+    eav[':planName'] = input.planName;
+    updateExpression.push('#planName = :planName');
+  }
+  updateExpression.sort();
+
+  return {
+    ExpressionAttributeNames: ean,
+    ExpressionAttributeValues: eav,
+    UpdateExpression: `SET ${updateExpression.join(', ')}`,
+  };
+}
+
+/** Unmarshalls a DynamoDB record into a Subscription object */
+export function unmarshallSubscription(
+  item: Record<string, any>
+): Subscription {
+  if ('_ct' in item) {
+    assert(
+      item._ct !== null,
+      () => new DataIntegrityError('Expected createdAt to be non-null')
+    );
+    assert(
+      typeof item._ct !== 'undefined',
+      () => new DataIntegrityError('Expected createdAt to be defined')
+    );
+  }
+  if ('effective_date' in item) {
+    assert(
+      item.effective_date !== null,
+      () => new DataIntegrityError('Expected effectiveDate to be non-null')
+    );
+    assert(
+      typeof item.effective_date !== 'undefined',
+      () => new DataIntegrityError('Expected effectiveDate to be defined')
+    );
+  }
+  if ('external_id' in item) {
+    assert(
+      item.external_id !== null,
+      () => new DataIntegrityError('Expected externalId to be non-null')
+    );
+    assert(
+      typeof item.external_id !== 'undefined',
+      () => new DataIntegrityError('Expected externalId to be defined')
+    );
+  }
+  if ('id' in item) {
+    assert(
+      item.id !== null,
+      () => new DataIntegrityError('Expected id to be non-null')
+    );
+    assert(
+      typeof item.id !== 'undefined',
+      () => new DataIntegrityError('Expected id to be defined')
+    );
+  }
+  if ('_md' in item) {
+    assert(
+      item._md !== null,
+      () => new DataIntegrityError('Expected updatedAt to be non-null')
+    );
+    assert(
+      typeof item._md !== 'undefined',
+      () => new DataIntegrityError('Expected updatedAt to be defined')
+    );
+  }
+  if ('vendor' in item) {
+    assert(
+      item.vendor !== null,
+      () => new DataIntegrityError('Expected vendor to be non-null')
+    );
+    assert(
+      typeof item.vendor !== 'undefined',
+      () => new DataIntegrityError('Expected vendor to be defined')
+    );
+  }
+  if ('_v' in item) {
+    assert(
+      item._v !== null,
+      () => new DataIntegrityError('Expected version to be non-null')
+    );
+    assert(
+      typeof item._v !== 'undefined',
+      () => new DataIntegrityError('Expected version to be defined')
+    );
+  }
+
+  let result: Subscription = {
+    createdAt: new Date(item._ct),
+    effectiveDate: new Date(item.effective_date),
+    externalId: item.external_id,
+    id: Base64.encode(`Subscription:${item.pk}#:#${item.sk}`),
+    updatedAt: new Date(item._md),
+    vendor: item.vendor,
+    version: item._v,
+  };
+
+  if ('cancelled' in item) {
+    result = {
+      ...result,
+      cancelled: item.cancelled,
+    };
+  }
+
+  if ('on_free_trial' in item) {
+    result = {
+      ...result,
+      onFreeTrial: item.on_free_trial,
+    };
+  }
+
+  if ('plan_name' in item) {
+    result = {
+      ...result,
+      planName: item.plan_name,
+    };
+  }
+
+  return result;
+}

--- a/examples/single-table-design/__generated__/actions.ts
+++ b/examples/single-table-design/__generated__/actions.ts
@@ -111,6 +111,34 @@ export interface QueryNodeArgs {
   id: Scalars['ID'];
 }
 
+export type ScheduledEmail = Model &
+  Timestamped &
+  Versioned & {
+    __typename?: 'ScheduledEmail';
+    createdAt: Scalars['Date'];
+    expires?: Maybe<Scalars['Date']>;
+    externalId: Scalars['String'];
+    id: Scalars['ID'];
+    template: Scalars['String'];
+    updatedAt: Scalars['Date'];
+    vendor: Vendor;
+    version: Scalars['Int'];
+  };
+
+export type SentEmail = Model &
+  Timestamped &
+  Versioned & {
+    __typename?: 'SentEmail';
+    createdAt: Scalars['Date'];
+    externalId: Scalars['String'];
+    id: Scalars['ID'];
+    messageId: Scalars['String'];
+    template: Scalars['String'];
+    updatedAt: Scalars['Date'];
+    vendor: Vendor;
+    version: Scalars['Int'];
+  };
+
 /** An object to track a user's logins */
 export type Subscription = Model &
   Node &
@@ -826,6 +854,1339 @@ export function unmarshallAccount(item: Record<string, any>): Account {
       planName: item.plan_name,
     };
   }
+
+  return result;
+}
+
+export interface ScheduledEmailPrimaryKey {
+  externalId: Scalars['String'];
+  template: Scalars['String'];
+  vendor: Vendor;
+}
+
+export type CreateScheduledEmailInput = Omit<
+  ScheduledEmail,
+  'createdAt' | 'expires' | 'id' | 'updatedAt' | 'version'
+> &
+  Partial<Pick<ScheduledEmail, 'expires'>>;
+export type CreateScheduledEmailOutput = ResultType<ScheduledEmail>;
+/**  */
+export async function createScheduledEmail(
+  input: Readonly<CreateScheduledEmailInput>
+): Promise<Readonly<CreateScheduledEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallScheduledEmail(input);
+  // Reminder: we use UpdateCommand rather than PutCommand because PutCommand
+  // cannot return the newly written values.
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ConditionExpression: 'attribute_not_exists(#pk)',
+      ExpressionAttributeNames,
+      ExpressionAttributeValues,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `SCHEDULED_EMAIL#${input.template}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'ScheduledEmail',
+    () =>
+      new DataIntegrityError(
+        `Expected to write ScheduledEmail but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallScheduledEmail(item),
+    metrics,
+  };
+}
+
+export type BlindWriteScheduledEmailInput = Omit<
+  ScheduledEmail,
+  'createdAt' | 'expires' | 'id' | 'updatedAt' | 'version'
+> &
+  Partial<Pick<ScheduledEmail, 'expires'>>;
+export type BlindWriteScheduledEmailOutput = ResultType<ScheduledEmail>;
+/** */
+export async function blindWriteScheduledEmail(
+  input: Readonly<BlindWriteScheduledEmailInput>
+): Promise<Readonly<BlindWriteScheduledEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallScheduledEmail(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `SCHEDULED_EMAIL#${input.template}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'ScheduledEmail',
+    () =>
+      new DataIntegrityError(
+        `Expected to write ScheduledEmail but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallScheduledEmail(item),
+    metrics,
+  };
+}
+
+export type DeleteScheduledEmailOutput = ResultType<void>;
+
+/**  */
+export async function deleteScheduledEmail(
+  input: ScheduledEmailPrimaryKey
+): Promise<DeleteScheduledEmailOutput> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new DeleteCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `SCHEDULED_EMAIL#${input.template}`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'NONE',
+          TableName: tableName,
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('ScheduledEmail', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type ReadScheduledEmailOutput = ResultType<ScheduledEmail>;
+
+/**  */
+export async function readScheduledEmail(
+  input: ScheduledEmailPrimaryKey
+): Promise<Readonly<ReadScheduledEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+
+  const {ConsumedCapacity: capacity, Item: item} = await ddbDocClient.send(
+    new GetCommand({
+      ConsistentRead: false,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `SCHEDULED_EMAIL#${input.template}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      TableName: tableName,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, () => new NotFoundError('ScheduledEmail', input));
+  assert(
+    item._et === 'ScheduledEmail',
+    () =>
+      new DataIntegrityError(
+        `Expected ${JSON.stringify(
+          input
+        )} to load a ScheduledEmail but loaded ${item._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallScheduledEmail(item),
+    metrics: undefined,
+  };
+}
+
+export type TouchScheduledEmailOutput = ResultType<void>;
+
+/**  */
+export async function touchScheduledEmail(
+  input: ScheduledEmailPrimaryKey
+): Promise<TouchScheduledEmailOutput> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new UpdateCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#expires': 'ttl',
+            '#pk': 'pk',
+            '#version': '_v',
+          },
+          ExpressionAttributeValues: {
+            ':ttlInc': 86400000,
+            ':versionInc': 1,
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `SCHEDULED_EMAIL#${input.template}`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'ALL_NEW',
+          TableName: tableName,
+          UpdateExpression:
+            'SET #expires = #expires + :ttlInc, #version = #version + :versionInc',
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('ScheduledEmail', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type UpdateScheduledEmailInput = Omit<
+  ScheduledEmail,
+  'createdAt' | 'expires' | 'id' | 'updatedAt'
+> &
+  Partial<Pick<ScheduledEmail, 'expires'>>;
+export type UpdateScheduledEmailOutput = ResultType<ScheduledEmail>;
+
+/**  */
+export async function updateScheduledEmail(
+  input: Readonly<UpdateScheduledEmailInput>
+): Promise<Readonly<UpdateScheduledEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallScheduledEmail(input);
+  try {
+    const {
+      Attributes: item,
+      ConsumedCapacity: capacity,
+      ItemCollectionMetrics: metrics,
+    } = await ddbDocClient.send(
+      new UpdateCommand({
+        ConditionExpression:
+          '#version = :previousVersion AND #entity = :entity AND attribute_exists(#pk)',
+        ExpressionAttributeNames,
+        ExpressionAttributeValues: {
+          ...ExpressionAttributeValues,
+          ':previousVersion': input.version,
+        },
+        Key: {
+          pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+          sk: `SCHEDULED_EMAIL#${input.template}`,
+        },
+        ReturnConsumedCapacity: 'INDEXES',
+        ReturnItemCollectionMetrics: 'SIZE',
+        ReturnValues: 'ALL_NEW',
+        TableName: tableName,
+        UpdateExpression,
+      })
+    );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+    assert(
+      item._et === 'ScheduledEmail',
+      () =>
+        new DataIntegrityError(
+          `Expected ${JSON.stringify({
+            externalId: input.externalId,
+            template: input.template,
+            vendor: input.vendor,
+          })} to update a ScheduledEmail but updated ${item._et} instead`
+        )
+    );
+
+    return {
+      capacity,
+      item: unmarshallScheduledEmail(item),
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      try {
+        await readScheduledEmail(input);
+      } catch {
+        throw new NotFoundError('ScheduledEmail', {
+          externalId: input.externalId,
+          template: input.template,
+          vendor: input.vendor,
+        });
+      }
+      throw new OptimisticLockingError('ScheduledEmail', {
+        externalId: input.externalId,
+        template: input.template,
+        vendor: input.vendor,
+      });
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type QueryScheduledEmailInput =
+  | {externalId: Scalars['String']; vendor: Vendor}
+  | {
+      externalId: Scalars['String'];
+      template: Scalars['String'];
+      vendor: Vendor;
+    };
+export type QueryScheduledEmailOutput = MultiResultType<ScheduledEmail>;
+
+/** helper */
+function makePartitionKeyForQueryScheduledEmail(
+  input: QueryScheduledEmailInput
+): string {
+  if (!('index' in input)) {
+    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+  }
+
+  throw new Error('Could not construct partition key from input');
+}
+
+/** helper */
+function makeSortKeyForQueryScheduledEmail(
+  input: QueryScheduledEmailInput
+): string | undefined {
+  return ['SCHEDULED_EMAIL', 'template' in input && input.template]
+    .filter(Boolean)
+    .join('#');
+}
+
+/** helper */
+function makeEavPkForQueryScheduledEmail(
+  input: QueryScheduledEmailInput
+): string {
+  return 'pk';
+}
+
+/** helper */
+function makeEavSkForQueryScheduledEmail(
+  input: QueryScheduledEmailInput
+): string {
+  return 'sk';
+}
+
+/** queryScheduledEmail */
+export async function queryScheduledEmail(
+  input: Readonly<QueryScheduledEmailInput>,
+  {
+    limit = undefined,
+    operator = 'begins_with',
+    reverse = false,
+  }: QueryOptions = {}
+): Promise<Readonly<QueryScheduledEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+
+  const {ConsumedCapacity: capacity, Items: items = []} =
+    await ddbDocClient.send(
+      new QueryCommand({
+        ConsistentRead: false,
+        ExpressionAttributeNames: {
+          '#pk': makeEavPkForQueryScheduledEmail(input),
+          '#sk': makeEavSkForQueryScheduledEmail(input),
+        },
+        ExpressionAttributeValues: {
+          ':pk': makePartitionKeyForQueryScheduledEmail(input),
+          ':sk': makeSortKeyForQueryScheduledEmail(input),
+        },
+        IndexName: undefined,
+        KeyConditionExpression: `#pk = :pk AND ${
+          operator === 'begins_with'
+            ? 'begins_with(#sk, :sk)'
+            : `#sk ${operator} :sk`
+        }`,
+        Limit: limit,
+        ReturnConsumedCapacity: 'INDEXES',
+        ScanIndexForward: !reverse,
+        TableName: tableName,
+      })
+    );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  return {
+    capacity,
+    items: items.map((item) => {
+      assert(
+        item._et === 'ScheduledEmail',
+        () => new DataIntegrityError('TODO')
+      );
+      return unmarshallScheduledEmail(item);
+    }),
+  };
+}
+
+/** queries the ScheduledEmail table by primary key using a node id */
+export async function queryScheduledEmailByNodeId(
+  id: Scalars['ID']
+): Promise<Readonly<Omit<ResultType<ScheduledEmail>, 'metrics'>>> {
+  const primaryKeyValues = Base64.decode(id)
+    .split(':')
+    .slice(1)
+    .join(':')
+    .split('#');
+
+  const primaryKey: QueryScheduledEmailInput = {
+    vendor: primaryKeyValues[1] as Vendor,
+    externalId: primaryKeyValues[2],
+  };
+
+  if (typeof primaryKeyValues[2] !== 'undefined') {
+    // @ts-ignore - TSC will usually see this as an error because it determined
+    // that primaryKey is the no-sort-fields-specified version of the type.
+    primaryKey.template = primaryKeyValues[5];
+  }
+
+  const {capacity, items} = await queryScheduledEmail(primaryKey);
+
+  assert(
+    items.length > 0,
+    () => new NotFoundError('ScheduledEmail', primaryKey)
+  );
+  assert(
+    items.length < 2,
+    () => new DataIntegrityError(`Found multiple ScheduledEmail with id ${id}`)
+  );
+
+  return {capacity, item: items[0]};
+}
+
+export interface MarshallScheduledEmailOutput {
+  ExpressionAttributeNames: Record<string, string>;
+  ExpressionAttributeValues: Record<string, NativeAttributeValue>;
+  UpdateExpression: string;
+}
+
+export type MarshallScheduledEmailInput = Required<
+  Pick<ScheduledEmail, 'externalId' | 'template' | 'vendor'>
+> &
+  Partial<Pick<ScheduledEmail, 'expires' | 'version'>>;
+
+/** Marshalls a DynamoDB record into a ScheduledEmail object */
+export function marshallScheduledEmail(
+  input: MarshallScheduledEmailInput
+): MarshallScheduledEmailOutput {
+  const now = new Date();
+
+  const updateExpression: string[] = [
+    '#entity = :entity',
+    '#createdAt = :createdAt',
+    '#externalId = :externalId',
+    '#template = :template',
+    '#updatedAt = :updatedAt',
+    '#vendor = :vendor',
+    '#version = :version',
+  ];
+
+  const ean: Record<string, string> = {
+    '#entity': '_et',
+    '#pk': 'pk',
+    '#createdAt': '_ct',
+    '#externalId': 'external_id',
+    '#template': 'template',
+    '#updatedAt': '_md',
+    '#vendor': 'vendor',
+    '#version': '_v',
+  };
+
+  const eav: Record<string, unknown> = {
+    ':entity': 'ScheduledEmail',
+    ':externalId': input.externalId,
+    ':template': input.template,
+    ':vendor': input.vendor,
+    ':createdAt': now.getTime(),
+    ':updatedAt': now.getTime(),
+    ':version': ('version' in input ? input.version ?? 0 : 0) + 1,
+  };
+
+  if ('expires' in input && typeof input.expires !== 'undefined') {
+    assert(
+      !Number.isNaN(input.expires?.getTime()),
+      'expires was passed but is not a valid date'
+    );
+    ean['#expires'] = 'ttl';
+    eav[':expires'] = input.expires === null ? null : input.expires.getTime();
+    updateExpression.push('#expires = :expires');
+  } else {
+    ean['#expires'] = 'ttl';
+    eav[':expires'] = now.getTime() + 86400000;
+    updateExpression.push('#expires = :expires');
+  }
+
+  updateExpression.sort();
+
+  return {
+    ExpressionAttributeNames: ean,
+    ExpressionAttributeValues: eav,
+    UpdateExpression: `SET ${updateExpression.join(', ')}`,
+  };
+}
+
+/** Unmarshalls a DynamoDB record into a ScheduledEmail object */
+export function unmarshallScheduledEmail(
+  item: Record<string, any>
+): ScheduledEmail {
+  if ('_ct' in item) {
+    assert(
+      item._ct !== null,
+      () => new DataIntegrityError('Expected createdAt to be non-null')
+    );
+    assert(
+      typeof item._ct !== 'undefined',
+      () => new DataIntegrityError('Expected createdAt to be defined')
+    );
+  }
+  if ('external_id' in item) {
+    assert(
+      item.external_id !== null,
+      () => new DataIntegrityError('Expected externalId to be non-null')
+    );
+    assert(
+      typeof item.external_id !== 'undefined',
+      () => new DataIntegrityError('Expected externalId to be defined')
+    );
+  }
+  if ('id' in item) {
+    assert(
+      item.id !== null,
+      () => new DataIntegrityError('Expected id to be non-null')
+    );
+    assert(
+      typeof item.id !== 'undefined',
+      () => new DataIntegrityError('Expected id to be defined')
+    );
+  }
+  if ('template' in item) {
+    assert(
+      item.template !== null,
+      () => new DataIntegrityError('Expected template to be non-null')
+    );
+    assert(
+      typeof item.template !== 'undefined',
+      () => new DataIntegrityError('Expected template to be defined')
+    );
+  }
+  if ('_md' in item) {
+    assert(
+      item._md !== null,
+      () => new DataIntegrityError('Expected updatedAt to be non-null')
+    );
+    assert(
+      typeof item._md !== 'undefined',
+      () => new DataIntegrityError('Expected updatedAt to be defined')
+    );
+  }
+  if ('vendor' in item) {
+    assert(
+      item.vendor !== null,
+      () => new DataIntegrityError('Expected vendor to be non-null')
+    );
+    assert(
+      typeof item.vendor !== 'undefined',
+      () => new DataIntegrityError('Expected vendor to be defined')
+    );
+  }
+  if ('_v' in item) {
+    assert(
+      item._v !== null,
+      () => new DataIntegrityError('Expected version to be non-null')
+    );
+    assert(
+      typeof item._v !== 'undefined',
+      () => new DataIntegrityError('Expected version to be defined')
+    );
+  }
+
+  let result: ScheduledEmail = {
+    createdAt: new Date(item._ct),
+    externalId: item.external_id,
+    id: Base64.encode(`ScheduledEmail:${item.pk}#:#${item.sk}`),
+    template: item.template,
+    updatedAt: new Date(item._md),
+    vendor: item.vendor,
+    version: item._v,
+  };
+
+  if ('ttl' in item) {
+    result = {
+      ...result,
+      expires: item.ttl ? new Date(item.ttl) : null,
+    };
+  }
+
+  return result;
+}
+
+export interface SentEmailPrimaryKey {
+  createdAt: Scalars['Date'];
+  externalId: Scalars['String'];
+  template: Scalars['String'];
+  vendor: Vendor;
+}
+
+export type CreateSentEmailInput = Omit<
+  SentEmail,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type CreateSentEmailOutput = ResultType<SentEmail>;
+/**  */
+export async function createSentEmail(
+  input: Readonly<CreateSentEmailInput>
+): Promise<Readonly<CreateSentEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallSentEmail(input);
+  // Reminder: we use UpdateCommand rather than PutCommand because PutCommand
+  // cannot return the newly written values.
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ConditionExpression: 'attribute_not_exists(#pk)',
+      ExpressionAttributeNames,
+      ExpressionAttributeValues,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `TEMPLATE#${input.template}#${now.getTime()}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'SentEmail',
+    () =>
+      new DataIntegrityError(
+        `Expected to write SentEmail but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallSentEmail(item),
+    metrics,
+  };
+}
+
+export type BlindWriteSentEmailInput = Omit<
+  SentEmail,
+  'createdAt' | 'id' | 'updatedAt' | 'version'
+>;
+export type BlindWriteSentEmailOutput = ResultType<SentEmail>;
+/** */
+export async function blindWriteSentEmail(
+  input: Readonly<BlindWriteSentEmailInput>
+): Promise<Readonly<BlindWriteSentEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallSentEmail(input);
+
+  delete ExpressionAttributeNames['#pk'];
+  delete ExpressionAttributeValues[':version'];
+
+  const eav = {...ExpressionAttributeValues, ':one': 1};
+  const ue = `${UpdateExpression.split(', ')
+    .filter((e) => !e.startsWith('#version'))
+    .join(', ')} ADD #version :one`;
+
+  const {
+    ConsumedCapacity: capacity,
+    ItemCollectionMetrics: metrics,
+    Attributes: item,
+  } = await ddbDocClient.send(
+    new UpdateCommand({
+      ExpressionAttributeNames,
+      ExpressionAttributeValues: eav,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `TEMPLATE#${input.template}#${now.getTime()}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      ReturnItemCollectionMetrics: 'SIZE',
+      ReturnValues: 'ALL_NEW',
+      TableName: tableName,
+      UpdateExpression: ue,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+  assert(
+    item._et === 'SentEmail',
+    () =>
+      new DataIntegrityError(
+        `Expected to write SentEmail but wrote ${item?._et} instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallSentEmail(item),
+    metrics,
+  };
+}
+
+export type DeleteSentEmailOutput = ResultType<void>;
+
+/**  */
+export async function deleteSentEmail(
+  input: SentEmailPrimaryKey
+): Promise<DeleteSentEmailOutput> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new DeleteCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `TEMPLATE#${input.template}#${now.getTime()}`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'NONE',
+          TableName: tableName,
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('SentEmail', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type ReadSentEmailOutput = ResultType<SentEmail>;
+
+/**  */
+export async function readSentEmail(
+  input: SentEmailPrimaryKey
+): Promise<Readonly<ReadSentEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+
+  const {ConsumedCapacity: capacity, Item: item} = await ddbDocClient.send(
+    new GetCommand({
+      ConsistentRead: false,
+      Key: {
+        pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+        sk: `TEMPLATE#${input.template}#${now.getTime()}`,
+      },
+      ReturnConsumedCapacity: 'INDEXES',
+      TableName: tableName,
+    })
+  );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  assert(item, () => new NotFoundError('SentEmail', input));
+  assert(
+    item._et === 'SentEmail',
+    () =>
+      new DataIntegrityError(
+        `Expected ${JSON.stringify(input)} to load a SentEmail but loaded ${
+          item._et
+        } instead`
+      )
+  );
+
+  return {
+    capacity,
+    item: unmarshallSentEmail(item),
+    metrics: undefined,
+  };
+}
+
+export type TouchSentEmailOutput = ResultType<void>;
+
+/**  */
+export async function touchSentEmail(
+  input: SentEmailPrimaryKey
+): Promise<TouchSentEmailOutput> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  try {
+    const {ConsumedCapacity: capacity, ItemCollectionMetrics: metrics} =
+      await ddbDocClient.send(
+        new UpdateCommand({
+          ConditionExpression: 'attribute_exists(#pk)',
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+            '#version': '_v',
+          },
+          ExpressionAttributeValues: {
+            ':versionInc': 1,
+          },
+          Key: {
+            pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+            sk: `TEMPLATE#${input.template}#${now.getTime()}`,
+          },
+          ReturnConsumedCapacity: 'INDEXES',
+          ReturnItemCollectionMetrics: 'SIZE',
+          ReturnValues: 'ALL_NEW',
+          TableName: tableName,
+          UpdateExpression: 'SET #version = #version + :versionInc',
+        })
+      );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    return {
+      capacity,
+      item: undefined,
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new NotFoundError('SentEmail', input);
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type UpdateSentEmailInput = Omit<
+  SentEmail,
+  'createdAt' | 'id' | 'updatedAt'
+>;
+export type UpdateSentEmailOutput = ResultType<SentEmail>;
+
+/**  */
+export async function updateSentEmail(
+  input: Readonly<UpdateSentEmailInput>
+): Promise<Readonly<UpdateSentEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+  const {
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    UpdateExpression,
+  } = marshallSentEmail(input);
+  try {
+    const {
+      Attributes: item,
+      ConsumedCapacity: capacity,
+      ItemCollectionMetrics: metrics,
+    } = await ddbDocClient.send(
+      new UpdateCommand({
+        ConditionExpression:
+          '#version = :previousVersion AND #entity = :entity AND attribute_exists(#pk)',
+        ExpressionAttributeNames,
+        ExpressionAttributeValues: {
+          ...ExpressionAttributeValues,
+          ':previousVersion': input.version,
+        },
+        Key: {
+          pk: `ACCOUNT#${input.vendor}#${input.externalId}`,
+          sk: `TEMPLATE#${input.template}#${now.getTime()}`,
+        },
+        ReturnConsumedCapacity: 'INDEXES',
+        ReturnItemCollectionMetrics: 'SIZE',
+        ReturnValues: 'ALL_NEW',
+        TableName: tableName,
+        UpdateExpression,
+      })
+    );
+
+    assert(
+      capacity,
+      'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+    );
+
+    assert(item, 'Expected DynamoDB ot return an Attributes prop.');
+    assert(
+      item._et === 'SentEmail',
+      () =>
+        new DataIntegrityError(
+          `Expected ${JSON.stringify({
+            createdAt: input.createdAt,
+            externalId: input.externalId,
+            template: input.template,
+            vendor: input.vendor,
+          })} to update a SentEmail but updated ${item._et} instead`
+        )
+    );
+
+    return {
+      capacity,
+      item: unmarshallSentEmail(item),
+      metrics,
+    };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      try {
+        await readSentEmail(input);
+      } catch {
+        throw new NotFoundError('SentEmail', {
+          createdAt: input.createdAt,
+          externalId: input.externalId,
+          template: input.template,
+          vendor: input.vendor,
+        });
+      }
+      throw new OptimisticLockingError('SentEmail', {
+        createdAt: input.createdAt,
+        externalId: input.externalId,
+        template: input.template,
+        vendor: input.vendor,
+      });
+    }
+    if (err instanceof ServiceException) {
+      throw new UnexpectedAwsError(err);
+    }
+    throw new UnexpectedError(err);
+  }
+}
+
+export type QuerySentEmailInput =
+  | {externalId: Scalars['String']; vendor: Vendor}
+  | {externalId: Scalars['String']; template: Scalars['String']; vendor: Vendor}
+  | {
+      createdAt: Scalars['Date'];
+      externalId: Scalars['String'];
+      template: Scalars['String'];
+      vendor: Vendor;
+    };
+export type QuerySentEmailOutput = MultiResultType<SentEmail>;
+
+/** helper */
+function makePartitionKeyForQuerySentEmail(input: QuerySentEmailInput): string {
+  if (!('index' in input)) {
+    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+  }
+
+  throw new Error('Could not construct partition key from input');
+}
+
+/** helper */
+function makeSortKeyForQuerySentEmail(
+  input: QuerySentEmailInput
+): string | undefined {
+  return [
+    'TEMPLATE',
+    'template' in input && input.template,
+    'createdAt' in input && input.createdAt,
+  ]
+    .filter(Boolean)
+    .join('#');
+}
+
+/** helper */
+function makeEavPkForQuerySentEmail(input: QuerySentEmailInput): string {
+  return 'pk';
+}
+
+/** helper */
+function makeEavSkForQuerySentEmail(input: QuerySentEmailInput): string {
+  return 'sk';
+}
+
+/** querySentEmail */
+export async function querySentEmail(
+  input: Readonly<QuerySentEmailInput>,
+  {
+    limit = undefined,
+    operator = 'begins_with',
+    reverse = false,
+  }: QueryOptions = {}
+): Promise<Readonly<QuerySentEmailOutput>> {
+  const tableName = process.env.TABLE_EMAIL;
+  assert(tableName, 'TABLE_EMAIL is not set');
+
+  const {ConsumedCapacity: capacity, Items: items = []} =
+    await ddbDocClient.send(
+      new QueryCommand({
+        ConsistentRead: false,
+        ExpressionAttributeNames: {
+          '#pk': makeEavPkForQuerySentEmail(input),
+          '#sk': makeEavSkForQuerySentEmail(input),
+        },
+        ExpressionAttributeValues: {
+          ':pk': makePartitionKeyForQuerySentEmail(input),
+          ':sk': makeSortKeyForQuerySentEmail(input),
+        },
+        IndexName: undefined,
+        KeyConditionExpression: `#pk = :pk AND ${
+          operator === 'begins_with'
+            ? 'begins_with(#sk, :sk)'
+            : `#sk ${operator} :sk`
+        }`,
+        Limit: limit,
+        ReturnConsumedCapacity: 'INDEXES',
+        ScanIndexForward: !reverse,
+        TableName: tableName,
+      })
+    );
+
+  assert(
+    capacity,
+    'Expected ConsumedCapacity to be returned. This is a bug in codegen.'
+  );
+
+  return {
+    capacity,
+    items: items.map((item) => {
+      assert(item._et === 'SentEmail', () => new DataIntegrityError('TODO'));
+      return unmarshallSentEmail(item);
+    }),
+  };
+}
+
+/** queries the SentEmail table by primary key using a node id */
+export async function querySentEmailByNodeId(
+  id: Scalars['ID']
+): Promise<Readonly<Omit<ResultType<SentEmail>, 'metrics'>>> {
+  const primaryKeyValues = Base64.decode(id)
+    .split(':')
+    .slice(1)
+    .join(':')
+    .split('#');
+
+  const primaryKey: QuerySentEmailInput = {
+    vendor: primaryKeyValues[1] as Vendor,
+    externalId: primaryKeyValues[2],
+  };
+
+  if (typeof primaryKeyValues[2] !== 'undefined') {
+    // @ts-ignore - TSC will usually see this as an error because it determined
+    // that primaryKey is the no-sort-fields-specified version of the type.
+    primaryKey.template = primaryKeyValues[5];
+  }
+
+  if (typeof primaryKeyValues[3] !== 'undefined') {
+    // @ts-ignore - TSC will usually see this as an error because it determined
+    // that primaryKey is the no-sort-fields-specified version of the type.
+    primaryKey.createdAt = new Date(primaryKeyValues[6]);
+  }
+
+  const {capacity, items} = await querySentEmail(primaryKey);
+
+  assert(items.length > 0, () => new NotFoundError('SentEmail', primaryKey));
+  assert(
+    items.length < 2,
+    () => new DataIntegrityError(`Found multiple SentEmail with id ${id}`)
+  );
+
+  return {capacity, item: items[0]};
+}
+
+export interface MarshallSentEmailOutput {
+  ExpressionAttributeNames: Record<string, string>;
+  ExpressionAttributeValues: Record<string, NativeAttributeValue>;
+  UpdateExpression: string;
+}
+
+export type MarshallSentEmailInput = Required<
+  Pick<SentEmail, 'externalId' | 'messageId' | 'template' | 'vendor'>
+> &
+  Partial<Pick<SentEmail, 'version'>>;
+
+/** Marshalls a DynamoDB record into a SentEmail object */
+export function marshallSentEmail(
+  input: MarshallSentEmailInput
+): MarshallSentEmailOutput {
+  const now = new Date();
+
+  const updateExpression: string[] = [
+    '#entity = :entity',
+    '#createdAt = :createdAt',
+    '#externalId = :externalId',
+    '#messageId = :messageId',
+    '#template = :template',
+    '#updatedAt = :updatedAt',
+    '#vendor = :vendor',
+    '#version = :version',
+  ];
+
+  const ean: Record<string, string> = {
+    '#entity': '_et',
+    '#pk': 'pk',
+    '#createdAt': '_ct',
+    '#externalId': 'external_id',
+    '#messageId': 'message_id',
+    '#template': 'template',
+    '#updatedAt': '_md',
+    '#vendor': 'vendor',
+    '#version': '_v',
+  };
+
+  const eav: Record<string, unknown> = {
+    ':entity': 'SentEmail',
+    ':externalId': input.externalId,
+    ':messageId': input.messageId,
+    ':template': input.template,
+    ':vendor': input.vendor,
+    ':createdAt': now.getTime(),
+    ':updatedAt': now.getTime(),
+    ':version': ('version' in input ? input.version ?? 0 : 0) + 1,
+  };
+
+  updateExpression.sort();
+
+  return {
+    ExpressionAttributeNames: ean,
+    ExpressionAttributeValues: eav,
+    UpdateExpression: `SET ${updateExpression.join(', ')}`,
+  };
+}
+
+/** Unmarshalls a DynamoDB record into a SentEmail object */
+export function unmarshallSentEmail(item: Record<string, any>): SentEmail {
+  if ('_ct' in item) {
+    assert(
+      item._ct !== null,
+      () => new DataIntegrityError('Expected createdAt to be non-null')
+    );
+    assert(
+      typeof item._ct !== 'undefined',
+      () => new DataIntegrityError('Expected createdAt to be defined')
+    );
+  }
+  if ('external_id' in item) {
+    assert(
+      item.external_id !== null,
+      () => new DataIntegrityError('Expected externalId to be non-null')
+    );
+    assert(
+      typeof item.external_id !== 'undefined',
+      () => new DataIntegrityError('Expected externalId to be defined')
+    );
+  }
+  if ('id' in item) {
+    assert(
+      item.id !== null,
+      () => new DataIntegrityError('Expected id to be non-null')
+    );
+    assert(
+      typeof item.id !== 'undefined',
+      () => new DataIntegrityError('Expected id to be defined')
+    );
+  }
+  if ('message_id' in item) {
+    assert(
+      item.message_id !== null,
+      () => new DataIntegrityError('Expected messageId to be non-null')
+    );
+    assert(
+      typeof item.message_id !== 'undefined',
+      () => new DataIntegrityError('Expected messageId to be defined')
+    );
+  }
+  if ('template' in item) {
+    assert(
+      item.template !== null,
+      () => new DataIntegrityError('Expected template to be non-null')
+    );
+    assert(
+      typeof item.template !== 'undefined',
+      () => new DataIntegrityError('Expected template to be defined')
+    );
+  }
+  if ('_md' in item) {
+    assert(
+      item._md !== null,
+      () => new DataIntegrityError('Expected updatedAt to be non-null')
+    );
+    assert(
+      typeof item._md !== 'undefined',
+      () => new DataIntegrityError('Expected updatedAt to be defined')
+    );
+  }
+  if ('vendor' in item) {
+    assert(
+      item.vendor !== null,
+      () => new DataIntegrityError('Expected vendor to be non-null')
+    );
+    assert(
+      typeof item.vendor !== 'undefined',
+      () => new DataIntegrityError('Expected vendor to be defined')
+    );
+  }
+  if ('_v' in item) {
+    assert(
+      item._v !== null,
+      () => new DataIntegrityError('Expected version to be non-null')
+    );
+    assert(
+      typeof item._v !== 'undefined',
+      () => new DataIntegrityError('Expected version to be defined')
+    );
+  }
+
+  const result: SentEmail = {
+    createdAt: new Date(item._ct),
+    externalId: item.external_id,
+    id: Base64.encode(`SentEmail:${item.pk}#:#${item.sk}`),
+    messageId: item.message_id,
+    template: item.template,
+    updatedAt: new Date(item._md),
+    vendor: item.vendor,
+    version: item._v,
+  };
 
   return result;
 }

--- a/examples/single-table-design/__generated__/dispatcher-table-accounts/index.ts
+++ b/examples/single-table-design/__generated__/dispatcher-table-accounts/index.ts
@@ -1,0 +1,10 @@
+// This file is generated. Do not edit by hand.
+
+import {makeDynamoDBStreamDispatcher} from '@ianwremmel/data';
+
+import * as dependencies from '../../../dependencies';
+
+export const handler = makeDynamoDBStreamDispatcher({
+  ...dependencies,
+  tableName: 'TableAccounts',
+});

--- a/examples/single-table-design/__generated__/handler-subscription/index.ts
+++ b/examples/single-table-design/__generated__/handler-subscription/index.ts
@@ -1,0 +1,15 @@
+// This file is generated. Do not edit by hand.
+
+import {assert, makeModelChangeHandler} from '@ianwremmel/data';
+
+import * as dependencies from '../../../dependencies';
+import {handler as cdcHandler} from '../../handler';
+import {unmarshallSubscription} from '../actions';
+
+export const handler = makeModelChangeHandler(dependencies, (record) => {
+  assert(
+    record.dynamodb.NewImage,
+    'Expected DynamoDB Record to have a NewImage'
+  );
+  return cdcHandler(unmarshallSubscription(record.dynamodb.NewImage));
+});

--- a/examples/single-table-design/__generated__/template.yml
+++ b/examples/single-table-design/__generated__/template.yml
@@ -10,6 +10,8 @@ Globals:
       Variables:
         TABLE_ACCOUNTS:
           Ref: TableAccounts
+        TABLE_EMAIL:
+          Ref: TableEmail
     Handler: index.handler
     MemorySize: 256
     Runtime: nodejs18.x
@@ -25,6 +27,15 @@ Outputs:
         Ref: TableAccounts
     Value:
       Ref: TableAccounts
+  TableEmail:
+    Description: The name of the DynamoDB table for TableEmail
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-TableEmail
+      Value:
+        Ref: TableEmail
+    Value:
+      Ref: TableEmail
 Parameters:
   LogRetentionInDays:
     Default: 3
@@ -118,12 +129,23 @@ Resources:
           AttributeType: S
         - AttributeName: sk
           AttributeType: S
+        - AttributeName: lsi1
+          AttributeType: S
       BillingMode: PAY_PER_REQUEST
       KeySchema:
         - AttributeName: pk
           KeyType: HASH
         - AttributeName: sk
           KeyType: RANGE
+      LocalSecondaryIndexes:
+        - IndexName: lsi1
+          KeySchema:
+            - AttributeName: pk
+              KeyType: HASH
+            - AttributeName: lsi1
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled:
           Fn::If:
@@ -187,4 +209,39 @@ Resources:
       RetentionInDays:
         Ref: LogRetentionInDays
     Type: AWS::Logs::LogGroup
+  TableEmail:
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
+      SSESpecification:
+        SSEEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
+      Tags:
+        - Key: StageName
+          Value:
+            Ref: StageName
+        - Key: TableName
+          Value: TableEmail
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+    Type: AWS::DynamoDB::Table
 Transform: AWS::Serverless-2016-10-31

--- a/examples/single-table-design/__generated__/template.yml
+++ b/examples/single-table-design/__generated__/template.yml
@@ -1,0 +1,190 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Conditions:
+  IsProd:
+    Fn::Equals:
+      - Ref: StageName
+      - production
+Globals:
+  Function:
+    Environment:
+      Variables:
+        TABLE_ACCOUNTS:
+          Ref: TableAccounts
+    Handler: index.handler
+    MemorySize: 256
+    Runtime: nodejs18.x
+    Timeout: 30
+    Tracing: Active
+Outputs:
+  TableAccounts:
+    Description: The name of the DynamoDB table for TableAccounts
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-TableAccounts
+      Value:
+        Ref: TableAccounts
+    Value:
+      Ref: TableAccounts
+Parameters:
+  LogRetentionInDays:
+    Default: 3
+    Description: Log retention in days
+    Type: Number
+  StageName:
+    AllowedValues:
+      - development
+      - production
+      - test
+    Default: development
+    Description: The name of the stage
+    Type: String
+Resources:
+  SubscriptionCDCHandler:
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - ./index
+        Minify: false
+        Sourcemap: true
+        Target: es2020
+    Properties:
+      CodeUri: handler-subscription
+      DeadLetterQueue:
+        TargetArn:
+          Fn::GetAtt:
+            - SubscriptionCDCHandlerEventBridgeDLQ
+            - Arn
+        Type: SQS
+      Events:
+        INSERT:
+          Properties:
+            DeadLetterConfig:
+              Arn:
+                Fn::GetAtt:
+                  - SubscriptionCDCHandlerDLQ
+                  - Arn
+            EventBusName: default
+            Pattern:
+              detail:
+                dynamodb:
+                  NewImage:
+                    _et:
+                      S:
+                        - Subscription
+              detail-type:
+                - INSERT
+              resources:
+                - Fn::GetAtt:
+                    - TableAccounts
+                    - Arn
+              source:
+                - TableAccounts.Subscription
+          Type: EventBridgeRule
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSLambda_ReadOnlyAccess
+        - AWSXrayWriteOnlyAccess
+        - CloudWatchLambdaInsightsExecutionRolePolicy
+        - CloudWatchPutMetricPolicy: {}
+        - DynamoDBCrudPolicy:
+            TableName:
+              Ref: TableAccounts
+        - SQSSendMessagePolicy:
+            QueueName:
+              Fn::GetAtt:
+                - SubscriptionCDCHandlerDLQ
+                - QueueName
+    Type: AWS::Serverless::Function
+  SubscriptionCDCHandlerDLQ:
+    Properties:
+      KmsMasterKeyId: alias/aws/sqs
+    Type: AWS::SQS::Queue
+  SubscriptionCDCHandlerEventBridgeDLQ:
+    Properties:
+      KmsMasterKeyId: alias/aws/sqs
+    Type: AWS::SQS::Queue
+  SubscriptionCDCHandlerLogGroup:
+    Properties:
+      LogGroupName:
+        Fn::Sub: /aws/lambda/${SubscriptionCDCHandler}
+      RetentionInDays:
+        Ref: LogRetentionInDays
+    Type: AWS::Logs::LogGroup
+  TableAccounts:
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
+      SSESpecification:
+        SSEEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
+      Tags:
+        - Key: StageName
+          Value:
+            Ref: StageName
+        - Key: TableName
+          Value: TableAccounts
+    Type: AWS::DynamoDB::Table
+  TableAccountsCDCDispatcher:
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - ./index
+        Minify: false
+        Sourcemap: true
+        Target: es2020
+    Properties:
+      CodeUri: dispatcher-table-accounts
+      Events:
+        Stream:
+          Properties:
+            BatchSize: 10
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            MaximumRetryAttempts: 3
+            StartingPosition: TRIM_HORIZON
+            Stream:
+              Fn::GetAtt:
+                - TableAccounts
+                - StreamArn
+          Type: DynamoDB
+      MemorySize: 384
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSLambda_ReadOnlyAccess
+        - AWSXrayWriteOnlyAccess
+        - CloudWatchLambdaInsightsExecutionRolePolicy
+        - CloudWatchPutMetricPolicy: {}
+        - EventBridgePutEventsPolicy:
+            EventBusName: default
+      Timeout: 60
+    Type: AWS::Serverless::Function
+  TableAccountsCDCDispatcherLogGroup:
+    Properties:
+      LogGroupName:
+        Fn::Sub: /aws/lambda/${TableAccountsCDCDispatcher}
+      RetentionInDays:
+        Ref: LogRetentionInDays
+    Type: AWS::Logs::LogGroup
+Transform: AWS::Serverless-2016-10-31

--- a/examples/single-table-design/handler.ts
+++ b/examples/single-table-design/handler.ts
@@ -1,0 +1,35 @@
+import type {Subscription} from './__generated__/actions';
+import {
+  createAccount,
+  readAccount,
+  updateAccount,
+} from './__generated__/actions';
+
+/** cdc handler */
+export async function handler(subscription: Subscription) {
+  try {
+    const {item: account} = await readAccount({
+      externalId: subscription.externalId,
+      vendor: subscription.vendor,
+    });
+
+    if (subscription.effectiveDate > account.effectiveDate) {
+      await updateAccount({
+        ...account,
+        cancelled: subscription.cancelled,
+        effectiveDate: subscription.effectiveDate,
+        onFreeTrial: subscription.onFreeTrial,
+        planName: subscription.planName,
+      });
+    }
+  } catch (err) {
+    await createAccount({
+      cancelled: subscription.cancelled,
+      effectiveDate: subscription.effectiveDate,
+      externalId: subscription.externalId,
+      onFreeTrial: subscription.onFreeTrial,
+      planName: subscription.planName,
+      vendor: subscription.vendor,
+    });
+  }
+}

--- a/examples/single-table-design/schema/account.graphqls
+++ b/examples/single-table-design/schema/account.graphqls
@@ -1,0 +1,23 @@
+"""
+An object to track a user's logins
+"""
+type Account implements Model & Node & Timestamped & Versioned
+  @compositeKey(
+    pkPrefix: "ACCOUNT"
+    pkFields: ["vendor", "externalId"]
+    skPrefix: "SUMMARY"
+    skFields: []
+  )
+  @secondaryIndex(name: "lsi1", fields: ["createdAt"], prefix: "INSTANCE")
+  @table(name: "TableAccounts") {
+  cancelled: Boolean
+  createdAt: Date!
+  effectiveDate: Date!
+  externalId: String!
+  id: ID!
+  onFreeTrial: Boolean
+  planName: PlanName
+  updatedAt: Date!
+  version: Int!
+  vendor: Vendor!
+}

--- a/examples/single-table-design/schema/email.graphqls
+++ b/examples/single-table-design/schema/email.graphqls
@@ -1,3 +1,6 @@
+"""
+Represents an email that is schedule to be sent to a user.
+"""
 type ScheduledEmail implements Model & Timestamped & Versioned
   @compositeKey(
     pkFields: ["vendor", "externalId"]
@@ -7,7 +10,7 @@ type ScheduledEmail implements Model & Timestamped & Versioned
   )
   @table(name: "TableEmail") {
   createdAt: Date!
-  expires: Date @ttl(duration: "1d")
+  sendAt: Date @ttl(duration: "1d")
   externalId: String!
   id: ID!
   template: String!
@@ -16,6 +19,9 @@ type ScheduledEmail implements Model & Timestamped & Versioned
   vendor: Vendor!
 }
 
+"""
+Represents an email that has been sent to a user
+"""
 type SentEmail implements Model & Timestamped & Versioned
   @compositeKey(
     pkFields: ["vendor", "externalId"]

--- a/examples/single-table-design/schema/email.graphqls
+++ b/examples/single-table-design/schema/email.graphqls
@@ -1,0 +1,35 @@
+type ScheduledEmail implements Model & Timestamped & Versioned
+  @compositeKey(
+    pkFields: ["vendor", "externalId"]
+    pkPrefix: "ACCOUNT"
+    skFields: ["template"]
+    skPrefix: "SCHEDULED_EMAIL"
+  )
+  @table(name: "TableEmail") {
+  createdAt: Date!
+  expires: Date @ttl(duration: "1d")
+  externalId: String!
+  id: ID!
+  template: String!
+  updatedAt: Date!
+  version: Int!
+  vendor: Vendor!
+}
+
+type SentEmail implements Model & Timestamped & Versioned
+  @compositeKey(
+    pkFields: ["vendor", "externalId"]
+    pkPrefix: "ACCOUNT"
+    skFields: ["template", "createdAt"]
+    skPrefix: "TEMPLATE"
+  )
+  @table(name: "TableEmail") {
+  createdAt: Date!
+  externalId: String!
+  id: ID!
+  messageId: String!
+  template: String!
+  updatedAt: Date!
+  vendor: Vendor!
+  version: Int!
+}

--- a/examples/single-table-design/schema/enums.graphqls
+++ b/examples/single-table-design/schema/enums.graphqls
@@ -1,0 +1,17 @@
+"""
+The available plans.
+"""
+enum PlanName {
+  OPEN_SOURCE
+  SMALL_TEAM
+  ENTERPRISE
+}
+
+"""
+Indicates which third-party this record came from.
+"""
+enum Vendor {
+  AZURE_DEV_OPS
+  GITHUB
+  GITLAB
+}

--- a/examples/single-table-design/schema/subscription.graphqls
+++ b/examples/single-table-design/schema/subscription.graphqls
@@ -1,0 +1,23 @@
+"""
+An object to track a user's logins
+"""
+type Subscription implements Model & Node & Timestamped & Versioned
+  @compositeKey(
+    pkPrefix: "ACCOUNT"
+    pkFields: ["vendor", "externalId"]
+    skPrefix: "SUBSCRIPTION"
+    skFields: ["effectiveDate"]
+  )
+  @cdc(event: "INSERT", handler: "../handler", produces: "Account")
+  @table(name: "TableAccounts") {
+  cancelled: Boolean
+  createdAt: Date!
+  effectiveDate: Date!
+  externalId: String!
+  id: ID!
+  onFreeTrial: Boolean
+  planName: PlanName
+  updatedAt: Date!
+  version: Int!
+  vendor: Vendor!
+}

--- a/examples/single-table-design/single-table-design.test.ts
+++ b/examples/single-table-design/single-table-design.test.ts
@@ -1,0 +1,110 @@
+import {faker} from '@faker-js/faker';
+import {NotFoundError} from '@ianwremmel/data';
+
+import {waitFor} from '../test-helpers';
+
+import {
+  createSubscription,
+  deleteAccount,
+  deleteSubscription,
+  readAccount,
+} from './__generated__/actions';
+
+describe('Single Table Design', () => {
+  // some part of the eventbridge setup doesn't work in localstack. This means
+  // there's no test for this in CI right now, but it works when tested locally
+  // against a real AWS account, which I don't want to wire into CI right now.
+  it(
+    'applies a custom mapper to update one model based on another',
+    async () => {
+      const externalId = String(faker.datatype.number());
+      const vendor = 'GITHUB';
+
+      // Confirm there is no record yet.
+      await expect(
+        async () => await readAccount({externalId, vendor})
+      ).rejects.toThrow(NotFoundError);
+
+      const {item: subscription1} = await createSubscription({
+        effectiveDate: faker.date.past(3),
+        externalId,
+        onFreeTrial: true,
+        planName: 'ENTERPRISE',
+        vendor,
+      });
+
+      let account = await waitFor(async () => {
+        const {item} = await readAccount({externalId, vendor});
+        expect(item).toBeDefined();
+        expect(item.version).toBe(1);
+        return item;
+      });
+      expect(account.planName).toBe('ENTERPRISE');
+      expect(account.onFreeTrial).toBe(true);
+      expect(account.cancelled).not.toBe(true);
+
+      const {item: subscription2} = await createSubscription({
+        effectiveDate: faker.date.future(0, account.effectiveDate),
+        externalId,
+        onFreeTrial: false,
+        planName: 'ENTERPRISE',
+        vendor,
+      });
+
+      account = await waitFor(async () => {
+        const {item} = await readAccount({externalId, vendor});
+        expect(item).toBeDefined();
+        expect(item.version).toBe(2);
+        return item;
+      });
+      expect(account.planName).toBe('ENTERPRISE');
+      expect(account.onFreeTrial).toBe(false);
+      expect(account.cancelled).not.toBe(true);
+
+      const {item: subscription3} = await createSubscription({
+        effectiveDate: faker.date.future(0, account.effectiveDate),
+        externalId,
+        onFreeTrial: false,
+        planName: 'SMALL_TEAM',
+        vendor,
+      });
+
+      account = await waitFor(async () => {
+        const {item} = await readAccount({externalId, vendor});
+        expect(item).toBeDefined();
+        expect(item.version).toBe(3);
+        return item;
+      });
+      expect(account.planName).toBe('SMALL_TEAM');
+      expect(account.onFreeTrial).toBe(false);
+      expect(account.cancelled).not.toBe(true);
+
+      const {item: subscription4} = await createSubscription({
+        cancelled: true,
+        effectiveDate: faker.date.future(0, account.effectiveDate),
+        externalId,
+        onFreeTrial: false,
+        planName: null,
+        vendor,
+      });
+
+      account = await waitFor(async () => {
+        const {item} = await readAccount({externalId, vendor});
+        expect(item).toBeDefined();
+        expect(item.version).toBe(4);
+        return item;
+      });
+      expect(account.planName).toBe(null);
+      expect(account.onFreeTrial).toBe(false);
+      expect(account.cancelled).toBe(true);
+
+      // cleanup
+      await deleteAccount(account);
+      await deleteSubscription(subscription1);
+      await deleteSubscription(subscription2);
+      await deleteSubscription(subscription3);
+      await deleteSubscription(subscription4);
+    },
+    5 * 60 * 1000
+  );
+});

--- a/examples/user-login/__generated__/template.yml
+++ b/examples/user-login/__generated__/template.yml
@@ -62,7 +62,11 @@ Resources:
         - AttributeName: sk
           KeyType: RANGE
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:

--- a/examples/user-session/__generated__/template.yml
+++ b/examples/user-session/__generated__/template.yml
@@ -45,7 +45,11 @@ Resources:
         - AttributeName: pk
           KeyType: HASH
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled:
+          Fn::If:
+            - IsProd
+            - true
+            - false
       SSESpecification:
         SSEEnabled:
           Fn::If:

--- a/examples/user-session/user-session.test.ts
+++ b/examples/user-session/user-session.test.ts
@@ -114,9 +114,10 @@ describe('blindWriteUserSession()', () => {
       sessionId: faker.datatype.uuid(),
     });
 
-    expect(result).toMatchInlineSnapshot(
-      itemMatcher,
-      `
+    try {
+      expect(result).toMatchInlineSnapshot(
+        itemMatcher,
+        `
       {
         "capacity": {
           "CapacityUnits": 1,
@@ -145,19 +146,20 @@ describe('blindWriteUserSession()', () => {
         "metrics": undefined,
       }
     `
-    );
+      );
 
-    expect(Base64.decode(result.item.id)).toMatchInlineSnapshot(
-      `"UserSession:USER_SESSION#181c887c-e7df-4331-9fba-65d255867e20"`
-    );
+      expect(Base64.decode(result.item.id)).toMatchInlineSnapshot(
+        `"UserSession:USER_SESSION#181c887c-e7df-4331-9fba-65d255867e20"`
+      );
 
-    expect(result.item.createdAt.getTime()).not.toBeNaN();
-    expect(result.item.expires.getTime()).not.toBeNaN();
-    expect(result.item.updatedAt.getTime()).not.toBeNaN();
-    expect(result.item.version).toBe(1);
-
-    // cleanup, not part of test
-    await deleteUserSession(result.item);
+      expect(result.item.createdAt.getTime()).not.toBeNaN();
+      expect(result.item.expires.getTime()).not.toBeNaN();
+      expect(result.item.updatedAt.getTime()).not.toBeNaN();
+      expect(result.item.version).toBe(1);
+    } finally {
+      // cleanup, not part of test
+      await deleteUserSession(result.item);
+    }
   });
 
   it('creates a user session with a custom expiration date if it does not exist', async () => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "require": "./dist/cjs/runtime/index.js"
     },
     "./codegen/actions": "./dist/codegen/actions.js",
-    "./codegen/cloudformation": "./dist/codegen/cloudformation.js"
+    "./codegen/cloudformation": "./dist/codegen/cloudformation.js",
+    "./codegen/parser": "./dist/codegen/parser.js"
   },
   "engines": {
     "node": "18.x",

--- a/src/codegen/actions/plugin.ts
+++ b/src/codegen/actions/plugin.ts
@@ -39,6 +39,7 @@ export const plugin: PluginFunction<ActionPluginConfig> = (
   info
 ) => {
   try {
+    const {models} = parse(schema, documents, config, info);
     const content = `export interface ResultType<T> {
   capacity: ConsumedCapacity;
   item: T;
@@ -50,7 +51,7 @@ export interface MultiResultType<T> {
   items: T[];
 }
 
-${parse(schema, documents, config, info)
+${models
   .map((table) => {
     return [
       `export interface ${table.typeName}PrimaryKey ${objectToString(

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -1,4 +1,4 @@
-import type {PrimaryKeyConfig, Table} from '../../parser';
+import type {PrimaryKeyConfig, Model} from '../../parser';
 
 import {blindWriteTpl} from './templates/blind-write';
 import {createItemTpl} from './templates/create-item';
@@ -12,76 +12,76 @@ import {updateItemTpl} from './templates/update-item';
 /**
  * Generates the createItem function for a table
  */
-export function createItemTemplate(irTable: Table) {
+export function createItemTemplate(model: Model) {
   return createItemTpl({
-    key: makeKey(irTable.primaryKey),
-    tableName: irTable.tableName,
-    ttlConfig: irTable.ttlConfig,
-    typeName: irTable.typeName,
+    key: makeKey(model.primaryKey),
+    tableName: model.tableName,
+    ttlConfig: model.ttlConfig,
+    typeName: model.typeName,
   });
 }
 
 /**
  * Generates the createItem function for a table
  */
-export function blindWriteTemplate(irTable: Table) {
+export function blindWriteTemplate(model: Model) {
   return blindWriteTpl({
-    key: makeKey(irTable.primaryKey),
-    tableName: irTable.tableName,
-    ttlConfig: irTable.ttlConfig,
-    typeName: irTable.typeName,
+    key: makeKey(model.primaryKey),
+    tableName: model.tableName,
+    ttlConfig: model.ttlConfig,
+    typeName: model.typeName,
   });
 }
 
 /**
  * Generates the deleteItem function for a table
  */
-export function deleteItemTemplate(irTable: Table) {
+export function deleteItemTemplate(model: Model) {
   return deleteItemTpl({
-    key: makeKey(irTable.primaryKey),
-    tableName: irTable.tableName,
-    typeName: irTable.typeName,
+    key: makeKey(model.primaryKey),
+    tableName: model.tableName,
+    typeName: model.typeName,
   });
 }
 
 /**
  * Generates the query function for a table
  */
-export function queryTemplate(irTable: Table) {
-  if (!irTable.primaryKey.isComposite) {
+export function queryTemplate(model: Model) {
+  if (!model.primaryKey.isComposite) {
     return '';
   }
 
   return queryTpl({
-    consistent: irTable.consistent,
-    primaryKey: irTable.primaryKey,
-    secondaryIndexes: irTable.secondaryIndexes,
-    tableName: irTable.tableName,
-    typeName: irTable.typeName,
+    consistent: model.consistent,
+    primaryKey: model.primaryKey,
+    secondaryIndexes: model.secondaryIndexes,
+    tableName: model.tableName,
+    typeName: model.typeName,
   });
 }
 
 /**
  * Generates the readItem function for a table
  */
-export function readItemTemplate(irTable: Table) {
+export function readItemTemplate(model: Model) {
   return readItemTpl({
-    consistent: irTable.consistent,
-    key: makeKey(irTable.primaryKey),
-    tableName: irTable.tableName,
-    typeName: irTable.typeName,
+    consistent: model.consistent,
+    key: makeKey(model.primaryKey),
+    tableName: model.tableName,
+    typeName: model.typeName,
   });
 }
 
 /**
  * Generates the updateItem function for a table
  */
-export function touchItemTemplate(irTable: Table) {
+export function touchItemTemplate(model: Model) {
   const ean: string[] = [];
   const eav: string[] = [];
   const updateExpressions: string[] = [];
 
-  for (const {fieldName} of irTable.fields) {
+  for (const {fieldName} of model.fields) {
     if (fieldName === 'id') {
       continue;
     } else if (fieldName === 'version') {
@@ -89,11 +89,11 @@ export function touchItemTemplate(irTable: Table) {
       eav.push(`':versionInc': 1`);
       updateExpressions.push(`#version = #version + :versionInc`);
     } else if (
-      fieldName === irTable.ttlConfig?.fieldName &&
-      irTable.ttlConfig.duration
+      fieldName === model.ttlConfig?.fieldName &&
+      model.ttlConfig.duration
     ) {
       ean.push(`'#${fieldName}': 'ttl'`);
-      eav.push(`':ttlInc': ${irTable.ttlConfig.duration}`);
+      eav.push(`':ttlInc': ${model.ttlConfig.duration}`);
       updateExpressions.push(`#${fieldName} = #${fieldName} + :ttlInc`);
     }
   }
@@ -107,9 +107,9 @@ export function touchItemTemplate(irTable: Table) {
   return touchItemTpl({
     ean,
     eav,
-    key: makeKey(irTable.primaryKey),
-    tableName: irTable.tableName,
-    typeName: irTable.typeName,
+    key: makeKey(model.primaryKey),
+    tableName: model.tableName,
+    typeName: model.typeName,
     updateExpressions,
   });
 }
@@ -117,26 +117,26 @@ export function touchItemTemplate(irTable: Table) {
 /**
  * Generates the updateItem function for a table
  */
-export function updateItemTemplate(irTable: Table) {
+export function updateItemTemplate(model: Model) {
   return updateItemTpl({
-    key: makeKey(irTable.primaryKey),
+    key: makeKey(model.primaryKey),
     marshallPrimaryKey: objectToString(
       Object.fromEntries(
-        (irTable.primaryKey.isComposite
+        (model.primaryKey.isComposite
           ? [
-              ...irTable.primaryKey.partitionKeyFields,
-              ...irTable.primaryKey.sortKeyFields,
+              ...model.primaryKey.partitionKeyFields,
+              ...model.primaryKey.sortKeyFields,
             ]
-          : irTable.primaryKey.partitionKeyFields
+          : model.primaryKey.partitionKeyFields
         )
           .map(({fieldName}) => fieldName)
           .sort()
           .map((fieldName) => [fieldName, `input.${fieldName}`])
       )
     ),
-    tableName: irTable.tableName,
-    ttlConfig: irTable.ttlConfig,
-    typeName: irTable.typeName,
+    tableName: model.tableName,
+    ttlConfig: model.ttlConfig,
+    typeName: model.typeName,
   });
 }
 

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -15,7 +15,6 @@ import {updateItemTpl} from './templates/update-item';
 export function createItemTemplate(irTable: Table) {
   return createItemTpl({
     key: makeKey(irTable.primaryKey),
-    omit: ['id', irTable.ttlConfig?.fieldName ?? ''].filter(Boolean),
     tableName: irTable.tableName,
     ttlConfig: irTable.ttlConfig,
     typeName: irTable.typeName,

--- a/src/codegen/actions/tables/templates/create-item.ts
+++ b/src/codegen/actions/tables/templates/create-item.ts
@@ -5,7 +5,6 @@ import {objectToString} from './helpers';
 
 export interface CreateItemTplInput {
   readonly key: Record<string, string>;
-  readonly omit: readonly string[];
   readonly tableName: string;
   readonly ttlConfig: TTLConfig | undefined;
   readonly typeName: string;
@@ -17,10 +16,16 @@ export function createItemTpl({
   key,
   tableName,
   typeName,
-  omit,
 }: CreateItemTplInput) {
   const inputTypeName = `Create${typeName}Input`;
-  const omitInputFields = ['createdAt', 'updatedAt', 'version', ...omit]
+  const omitInputFields = [
+    'createdAt',
+    'id',
+    'updatedAt',
+    'version',
+    ttlConfig?.fieldName,
+  ]
+    .filter(Boolean)
     .map((f) => `'${f}'`)
     .sort();
   const outputTypeName = `Create${typeName}Output`;

--- a/src/codegen/actions/tables/templates/marshall.ts
+++ b/src/codegen/actions/tables/templates/marshall.ts
@@ -34,9 +34,6 @@ export function marshallTpl({
   // These are fields that are required on the object but have explicit,
   // non-overridable behaviors
   const builtinDateFieldNames = ['createdAt', 'updatedAt'];
-  const builtinDateFields = requiredFields.filter(({fieldName}) =>
-    builtinDateFieldNames.includes(fieldName)
-  );
 
   const normalRequiredFields = requiredFields.filter(
     ({fieldName}) =>
@@ -66,13 +63,14 @@ export interface Marshall${typeName}Output {
 export type ${inputTypeName} = ${marshallType};
 
 /** Marshalls a DynamoDB record into a ${typeName} object */
-export function marshall${typeName}(input: ${inputTypeName}): Marshall${typeName}Output {
-  const now = new Date();
-
+export function marshall${typeName}(input: ${inputTypeName}, now = new Date()): Marshall${typeName}Output {
   const updateExpression: string[] = [
   "#entity = :entity",
   ${requiredFields
-    .filter(({fieldName}) => fieldName !== ttlConfig?.fieldName)
+    .filter(
+      ({fieldName}) =>
+        fieldName !== ttlConfig?.fieldName && fieldName !== 'createdAt'
+    )
     .map(({fieldName}) => `'#${fieldName} = :${fieldName}',`)
     .join('\n')}
   ${secondaryIndexes
@@ -89,7 +87,10 @@ export function marshall${typeName}(input: ${inputTypeName}): Marshall${typeName
     "#entity": "_et",
     "#pk": "pk",
 ${requiredFields
-  .filter(({fieldName}) => fieldName !== ttlConfig?.fieldName)
+  .filter(
+    ({fieldName}) =>
+      fieldName !== ttlConfig?.fieldName && fieldName !== 'createdAt'
+  )
   .map(({columnName, fieldName}) => `'#${fieldName}': '${columnName}',`)
   .join('\n')}
 ${secondaryIndexes
@@ -110,9 +111,7 @@ ${secondaryIndexes
           `':${fieldName}': ${marshallField(fieldName, isDateType)},`
       )
       .join('\n')}
-    ${builtinDateFields
-      .map(({fieldName}) => `':${fieldName}': now.getTime(),`)
-      .join('\n')}
+    ':updatedAt': now.getTime(),
     ${requiredFieldsWithDefaultBehaviors
       .map(({fieldName}) => {
         if (fieldName === 'version') {
@@ -134,19 +133,22 @@ ${secondaryIndexes
       ? [
           `':${index.name}pk': \`${makeKeyTemplate(
             index.partitionKeyPrefix,
-            index.partitionKeyFields
+            index.partitionKeyFields,
+            'read'
           )}\`,`,
           index.isComposite
             ? `':${index.name}sk': \`${makeKeyTemplate(
                 index.sortKeyPrefix,
-                index.sortKeyFields
+                index.sortKeyFields,
+                'read'
               )}\`,`
             : undefined,
         ]
       : [
           `':${index.name}sk': \`${makeKeyTemplate(
             index.sortKeyPrefix,
-            index.sortKeyFields
+            index.sortKeyFields,
+            'read'
           )}\`,`,
         ]
   )

--- a/src/codegen/actions/tables/templates/marshall.ts
+++ b/src/codegen/actions/tables/templates/marshall.ts
@@ -1,11 +1,11 @@
 import assert from 'assert';
 
-import type {Field, Table, TTLConfig} from '../../../parser';
+import type {Field, Model, TTLConfig} from '../../../parser';
 
 import {makeKeyTemplate, marshallField} from './helpers';
 
 export interface MarshallTplInput {
-  readonly table: Table;
+  readonly table: Model;
 }
 /** helper */
 function wrapFieldNameWithQuotes({fieldName}: Field): string {

--- a/src/codegen/actions/tables/templates/query.ts
+++ b/src/codegen/actions/tables/templates/query.ts
@@ -262,13 +262,21 @@ function makePartitionKeyForQuery(
 
       if (index.type === 'primary') {
         return `if (!('index' in input)) {
-  return \`${makeKeyTemplate(partitionKeyPrefix ?? '', partitionKeyFields)}\`
+  return \`${makeKeyTemplate(
+    partitionKeyPrefix ?? '',
+    partitionKeyFields,
+    'read'
+  )}\`
 }`;
       }
 
       return `
 if ('index' in input && input.index === '${index.name}') {
-  return \`${makeKeyTemplate(partitionKeyPrefix ?? '', partitionKeyFields)}\`;
+  return \`${makeKeyTemplate(
+    partitionKeyPrefix ?? '',
+    partitionKeyFields,
+    'read'
+  )}\`;
 }`;
     })
     .join('\n else ');

--- a/src/codegen/actions/tables/templates/unmarshall.ts
+++ b/src/codegen/actions/tables/templates/unmarshall.ts
@@ -1,11 +1,11 @@
-import type {Table} from '../../../parser';
+import type {Model} from '../../../parser';
 
 import {unmarshallField} from './helpers';
 
 export const DIVIDER = '#:#';
 
 export interface UnmarshallTplInput {
-  readonly table: Table;
+  readonly table: Model;
 }
 
 /** Generates the unmarshall function for a table */

--- a/src/codegen/actions/tables/templates/update-item.ts
+++ b/src/codegen/actions/tables/templates/update-item.ts
@@ -6,6 +6,7 @@ import {objectToString} from './helpers';
 export interface UpdateItemTplInput {
   readonly key: Record<string, string>;
   readonly marshallPrimaryKey: string;
+  readonly primaryKeyFields: string[];
   readonly tableName: string;
   readonly ttlConfig: TTLConfig | undefined;
   readonly typeName: string;
@@ -15,6 +16,7 @@ export interface UpdateItemTplInput {
 export function updateItemTpl({
   marshallPrimaryKey,
   key,
+  primaryKeyFields,
   tableName,
   ttlConfig,
   typeName,
@@ -26,6 +28,7 @@ export function updateItemTpl({
     'updatedAt',
     ...(ttlConfig ? [ttlConfig.fieldName] : []),
   ]
+    .filter((fieldName) => !primaryKeyFields.includes(fieldName))
     .map((f) => `'${f}'`)
     .sort();
   const outputTypeName = `Update${typeName}Output`;

--- a/src/codegen/cloudformation/table.ts
+++ b/src/codegen/cloudformation/table.ts
@@ -127,7 +127,7 @@ export function defineTable({
       : undefined,
     PointInTimeRecoverySpecification: enablePointInTimeRecovery
       ? {
-          PointInTimeRecoveryEnabled: true,
+          PointInTimeRecoveryEnabled: {'Fn::If': ['IsProd', true, false]},
         }
       : undefined,
     SSESpecification: {

--- a/src/codegen/cloudformation/table.ts
+++ b/src/codegen/cloudformation/table.ts
@@ -7,15 +7,13 @@ import type {CloudFormationFragment} from './types';
 /* eslint-disable complexity */
 /** cloudformation generator */
 export function defineTable({
-  changeDataCaptureConfig,
   enablePointInTimeRecovery,
+  hasCdc,
+  hasTtl,
   tableName,
   primaryKey: {isComposite},
   secondaryIndexes,
-  ttlConfig: ttlInfo,
 }: Table): CloudFormationFragment {
-  const hasCdc = !!changeDataCaptureConfig;
-
   const attributeDefinitions = isComposite
     ? [
         {
@@ -158,7 +156,7 @@ export function defineTable({
     delete properties.GlobalSecondaryIndexes;
   }
 
-  if (!ttlInfo) {
+  if (!hasTtl) {
     delete properties.TimeToLiveSpecification;
   }
 

--- a/src/codegen/parser/parser.ts
+++ b/src/codegen/parser/parser.ts
@@ -280,6 +280,13 @@ export function getAliasForField(field: GraphQLField<unknown, unknown>) {
   if (hasDirective('ttl', field)) {
     return 'ttl';
   }
+
+  if (hasDirective('alias', field)) {
+    const {astNode} = field;
+    assert(astNode);
+    return getArgStringValue('name', getDirective('alias', astNode));
+  }
+
   switch (field.name) {
     case 'version':
       return '_v';

--- a/src/codegen/parser/parser.ts
+++ b/src/codegen/parser/parser.ts
@@ -108,6 +108,15 @@ function extractFields(
     };
   });
 }
+/** helper */
+function getFieldFromFieldMap(
+  fieldMap: Record<string, Field>,
+  fieldName: string
+): Field {
+  const field = fieldMap[fieldName];
+  assert(field, `Expected field ${fieldName} to exist`);
+  return field;
+}
 
 /** helper */
 function extractPrimaryKey(
@@ -120,11 +129,11 @@ function extractPrimaryKey(
     return {
       isComposite: true,
       partitionKeyFields: getArgStringArrayValue('pkFields', directive).map(
-        (fieldName) => fieldMap[fieldName]
+        (fieldName) => getFieldFromFieldMap(fieldMap, fieldName)
       ),
       partitionKeyPrefix: getOptionalArgStringValue('pkPrefix', directive),
       sortKeyFields: getArgStringArrayValue('skFields', directive).map(
-        (fieldName) => fieldMap[fieldName]
+        (fieldName) => getFieldFromFieldMap(fieldMap, fieldName)
       ),
       sortKeyPrefix: getOptionalArgStringValue('skPrefix', directive),
       type: 'primary',
@@ -137,7 +146,7 @@ function extractPrimaryKey(
     return {
       isComposite: false,
       partitionKeyFields: getArgStringArrayValue('pkFields', directive).map(
-        (fieldName) => fieldMap[fieldName]
+        (fieldName) => getFieldFromFieldMap(fieldMap, fieldName)
       ),
       partitionKeyPrefix: getOptionalArgStringValue('pkPrefix', directive),
       type: 'primary',
@@ -169,13 +178,13 @@ function extractSecondaryIndexes(
             partitionKeyFields: getArgStringArrayValue(
               'pkFields',
               directive
-            ).map((fieldName) => fieldMap[fieldName]),
+            ).map((fieldName) => getFieldFromFieldMap(fieldMap, fieldName)),
             partitionKeyPrefix: getOptionalArgStringValue(
               'pkPrefix',
               directive
             ),
             sortKeyFields: getArgStringArrayValue('skFields', directive).map(
-              (fieldName) => fieldMap[fieldName]
+              (fieldName) => getFieldFromFieldMap(fieldMap, fieldName)
             ),
             sortKeyPrefix: getOptionalArgStringValue('skPrefix', directive),
             type: 'gsi',
@@ -188,7 +197,7 @@ function extractSecondaryIndexes(
           isComposite: true,
           name: getArgStringValue('name', directive),
           sortKeyFields: getArgStringArrayValue('fields', directive).map(
-            (fieldName) => fieldMap[fieldName]
+            (fieldName) => getFieldFromFieldMap(fieldMap, fieldName)
           ),
           sortKeyPrefix: getOptionalArgStringValue('prefix', directive),
           type: 'lsi',

--- a/src/codegen/parser/types.ts
+++ b/src/codegen/parser/types.ts
@@ -1,4 +1,25 @@
 export interface Table {
+  readonly dependenciesModuleId: string;
+  readonly enablePointInTimeRecovery: boolean;
+  readonly hasCdc: boolean;
+  readonly hasTtl: boolean;
+  readonly libImportPath: string;
+  readonly primaryKey: TablePrimaryKeyConfig;
+  readonly secondaryIndexes: readonly TableSecondaryIndex[];
+  readonly tableName: string;
+}
+
+export interface TablePrimaryKeyConfig {
+  readonly isComposite: boolean;
+}
+
+export interface TableSecondaryIndex {
+  readonly isComposite: boolean;
+  readonly name: string;
+  readonly type: 'gsi' | 'lsi';
+}
+
+export interface Model {
   readonly changeDataCaptureConfig?: ChangeDataCaptureConfig;
   readonly consistent: boolean;
   readonly dependenciesModuleId: string;

--- a/src/codegen/schema.graphqls
+++ b/src/codegen/schema.graphqls
@@ -9,6 +9,11 @@ Arbitrary JSON stored as a Map in DynamoDB
 scalar JSONObject
 
 """
+Allows specifiying an alternatie column name.
+"""
+directive @alias(name: String!) on FIELD_DEFINITION
+
+"""
 Indicates all reads for this type will be done using DynamoDB's
 strong-consistency mode. General discouraged, though certain user-facing flows
 might require it.


### PR DESCRIPTION
- refactor: remove omit prop from create-template
- feat: add "@alias"
- feat: make PointInTime recovery dependent on IsProd
- fix: ensure fields exist before using them as key fields
- feat: expose parser to project consumers and generate sourcemaps
- test: add single-table-design schema
- feat: split Model and Table defintion to support single table design
- fix: stop overwriting createdAt
