### PR TITLE
public id 2

### DIFF
--- a/examples/change-data-capture/__generated__/actions.ts
+++ b/examples/change-data-capture/__generated__/actions.ts
@@ -740,76 +740,59 @@ export function marshallAccount(
 
 /** Unmarshalls a DynamoDB record into a Account object */
 export function unmarshallAccount(item: Record<string, any>): Account {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('effective_date' in item) {
-    assert(
-      item.effective_date !== null,
-      () => new DataIntegrityError('Expected effectiveDate to be non-null')
-    );
-    assert(
-      typeof item.effective_date !== 'undefined',
-      () => new DataIntegrityError('Expected effectiveDate to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.effective_date !== null,
+    () => new DataIntegrityError('Expected effectiveDate to be non-null')
+  );
+  assert(
+    typeof item.effective_date !== 'undefined',
+    () => new DataIntegrityError('Expected effectiveDate to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: Account = {
     createdAt: new Date(item._ct),
@@ -1430,76 +1413,59 @@ export function marshallSubscription(
 export function unmarshallSubscription(
   item: Record<string, any>
 ): Subscription {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('effective_date' in item) {
-    assert(
-      item.effective_date !== null,
-      () => new DataIntegrityError('Expected effectiveDate to be non-null')
-    );
-    assert(
-      typeof item.effective_date !== 'undefined',
-      () => new DataIntegrityError('Expected effectiveDate to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.effective_date !== null,
+    () => new DataIntegrityError('Expected effectiveDate to be non-null')
+  );
+  assert(
+    typeof item.effective_date !== 'undefined',
+    () => new DataIntegrityError('Expected effectiveDate to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: Subscription = {
     createdAt: new Date(item._ct),

--- a/examples/change-data-capture/__generated__/actions.ts
+++ b/examples/change-data-capture/__generated__/actions.ts
@@ -547,45 +547,66 @@ export type QueryAccountInput =
 export type QueryAccountOutput = MultiResultType<Account>;
 
 /** helper */
-function makePartitionKeyForQueryAccount(input: QueryAccountInput): string {
-  if (!('index' in input)) {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
-  } else if ('index' in input && input.index === 'lsi1') {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
-  }
-
-  throw new Error('Could not construct partition key from input');
-}
-
-/** helper */
-function makeSortKeyForQueryAccount(
+function makeEanForQueryAccount(
   input: QueryAccountInput
-): string | undefined {
+): Record<string, string> {
   if ('index' in input) {
     if (input.index === 'lsi1') {
-      return ['INSTANCE', 'createdAt' in input && input.createdAt]
-        .filter(Boolean)
-        .join('#');
+      return {'#pk': 'pk', '#sk': 'sk'};
     }
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
   } else {
-    return ['SUMMARY'].filter(Boolean).join('#');
+    return {'#pk': 'pk', '#sk': 'sk'};
   }
 }
 
 /** helper */
-function makeEavPkForQueryAccount(input: QueryAccountInput): string {
-  return 'pk';
-}
-
-/** helper */
-function makeEavSkForQueryAccount(input: QueryAccountInput): string {
+function makeEavForQueryAccount(input: QueryAccountInput): Record<string, any> {
   if ('index' in input) {
-    const lsis = ['lsi1'];
-    if (lsis.includes(input.index)) {
-      return input.index;
+    if (input.index === 'lsi1') {
+      return {
+        ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+        ':sk': ['INSTANCE', 'createdAt' in input && input.createdAt]
+          .filter(Boolean)
+          .join('#'),
+      };
     }
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {
+      ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+      ':sk': ['SUMMARY'].filter(Boolean).join('#'),
+    };
   }
-  return 'sk';
+}
+
+/** helper */
+function makeKceForQueryAccount(
+  input: QueryAccountInput,
+  {operator}: Pick<QueryOptions, 'operator'>
+): string {
+  if ('index' in input) {
+    if (input.index === 'lsi1') {
+      return `#pk = :pk AND ${
+        operator === 'begins_with'
+          ? 'begins_with(#sk, :sk)'
+          : `#sk ${operator} :sk`
+      }`;
+    }
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return `#pk = :pk AND ${
+      operator === 'begins_with'
+        ? 'begins_with(#sk, :sk)'
+        : `#sk ${operator} :sk`
+    }`;
+  }
 }
 
 /** queryAccount */
@@ -600,24 +621,18 @@ export async function queryAccount(
   const tableName = process.env.TABLE_ACCOUNT;
   assert(tableName, 'TABLE_ACCOUNT is not set');
 
+  const ExpressionAttributeNames = makeEanForQueryAccount(input);
+  const ExpressionAttributeValues = makeEavForQueryAccount(input);
+  const KeyConditionExpression = makeKceForQueryAccount(input, {operator});
+
   const {ConsumedCapacity: capacity, Items: items = []} =
     await ddbDocClient.send(
       new QueryCommand({
         ConsistentRead: false,
-        ExpressionAttributeNames: {
-          '#pk': makeEavPkForQueryAccount(input),
-          '#sk': makeEavSkForQueryAccount(input),
-        },
-        ExpressionAttributeValues: {
-          ':pk': makePartitionKeyForQueryAccount(input),
-          ':sk': makeSortKeyForQueryAccount(input),
-        },
+        ExpressionAttributeNames,
+        ExpressionAttributeValues,
         IndexName: 'index' in input ? input.index : undefined,
-        KeyConditionExpression: `#pk = :pk AND ${
-          operator === 'begins_with'
-            ? 'begins_with(#sk, :sk)'
-            : `#sk ${operator} :sk`
-        }`,
+        KeyConditionExpression,
         Limit: limit,
         ReturnConsumedCapacity: 'INDEXES',
         ScanIndexForward: !reverse,
@@ -1225,33 +1240,52 @@ export type QuerySubscriptionInput =
 export type QuerySubscriptionOutput = MultiResultType<Subscription>;
 
 /** helper */
-function makePartitionKeyForQuerySubscription(
+function makeEanForQuerySubscription(
   input: QuerySubscriptionInput
-): string {
-  if (!('index' in input)) {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+): Record<string, string> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {'#pk': 'pk', '#sk': 'sk'};
   }
-
-  throw new Error('Could not construct partition key from input');
 }
 
 /** helper */
-function makeSortKeyForQuerySubscription(
+function makeEavForQuerySubscription(
   input: QuerySubscriptionInput
-): string | undefined {
-  return ['SUBSCRIPTION', 'effectiveDate' in input && input.effectiveDate]
-    .filter(Boolean)
-    .join('#');
+): Record<string, any> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {
+      ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+      ':sk': ['SUBSCRIPTION', 'effectiveDate' in input && input.effectiveDate]
+        .filter(Boolean)
+        .join('#'),
+    };
+  }
 }
 
 /** helper */
-function makeEavPkForQuerySubscription(input: QuerySubscriptionInput): string {
-  return 'pk';
-}
-
-/** helper */
-function makeEavSkForQuerySubscription(input: QuerySubscriptionInput): string {
-  return 'sk';
+function makeKceForQuerySubscription(
+  input: QuerySubscriptionInput,
+  {operator}: Pick<QueryOptions, 'operator'>
+): string {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return `#pk = :pk AND ${
+      operator === 'begins_with'
+        ? 'begins_with(#sk, :sk)'
+        : `#sk ${operator} :sk`
+    }`;
+  }
 }
 
 /** querySubscription */
@@ -1266,24 +1300,18 @@ export async function querySubscription(
   const tableName = process.env.TABLE_SUBSCRIPTION;
   assert(tableName, 'TABLE_SUBSCRIPTION is not set');
 
+  const ExpressionAttributeNames = makeEanForQuerySubscription(input);
+  const ExpressionAttributeValues = makeEavForQuerySubscription(input);
+  const KeyConditionExpression = makeKceForQuerySubscription(input, {operator});
+
   const {ConsumedCapacity: capacity, Items: items = []} =
     await ddbDocClient.send(
       new QueryCommand({
         ConsistentRead: false,
-        ExpressionAttributeNames: {
-          '#pk': makeEavPkForQuerySubscription(input),
-          '#sk': makeEavSkForQuerySubscription(input),
-        },
-        ExpressionAttributeValues: {
-          ':pk': makePartitionKeyForQuerySubscription(input),
-          ':sk': makeSortKeyForQuerySubscription(input),
-        },
+        ExpressionAttributeNames,
+        ExpressionAttributeValues,
         IndexName: undefined,
-        KeyConditionExpression: `#pk = :pk AND ${
-          operator === 'begins_with'
-            ? 'begins_with(#sk, :sk)'
-            : `#sk ${operator} :sk`
-        }`,
+        KeyConditionExpression,
         Limit: limit,
         ReturnConsumedCapacity: 'INDEXES',
         ScanIndexForward: !reverse,

--- a/examples/change-data-capture/__generated__/actions.ts
+++ b/examples/change-data-capture/__generated__/actions.ts
@@ -100,6 +100,20 @@ export interface Node {
 /** The available plans. */
 export type PlanName = 'ENTERPRISE' | 'OPEN_SOURCE' | 'SMALL_TEAM';
 
+/**
+ * Like Model, but includes a `publicId` field which, unline `id`, is semantically
+ * meaningless. Types implementing PublicModel will have an additional function,
+ * `queryByPublicId`, generated. If any of your models implement PublicModel, then
+ * the dependencies module must include an `idGenerator()`.
+ */
+export interface PublicModel {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  publicId: Scalars['String'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
 /** The Query type */
 export interface Query {
   __typename?: 'Query';

--- a/examples/dependencies.ts
+++ b/examples/dependencies.ts
@@ -11,6 +11,7 @@ import {
   captureAsyncFunc,
   getSegment,
 } from 'aws-xray-sdk-core';
+import cuid from 'cuid';
 
 /** Figure out the correct URL for lambda to lambda calls. */
 function getEndpointUrl() {
@@ -90,4 +91,9 @@ export async function captureAsyncFunction<R>(
       subsegment?.close();
     }
   });
+}
+
+/** Generates unique, random ids */
+export function idGenerator() {
+  return cuid();
 }

--- a/examples/existing-json-template/__generated__/actions.ts
+++ b/examples/existing-json-template/__generated__/actions.ts
@@ -79,6 +79,20 @@ export interface Node {
   id: Scalars['ID'];
 }
 
+/**
+ * Like Model, but includes a `publicId` field which, unline `id`, is semantically
+ * meaningless. Types implementing PublicModel will have an additional function,
+ * `queryByPublicId`, generated. If any of your models implement PublicModel, then
+ * the dependencies module must include an `idGenerator()`.
+ */
+export interface PublicModel {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  publicId: Scalars['String'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
 /** The Query type */
 export interface Query {
   __typename?: 'Query';

--- a/examples/existing-json-template/__generated__/actions.ts
+++ b/examples/existing-json-template/__generated__/actions.ts
@@ -725,76 +725,59 @@ export function marshallUserLogin(
 
 /** Unmarshalls a DynamoDB record into a UserLogin object */
 export function unmarshallUserLogin(item: Record<string, any>): UserLogin {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('login' in item) {
-    assert(
-      item.login !== null,
-      () => new DataIntegrityError('Expected login to be non-null')
-    );
-    assert(
-      typeof item.login !== 'undefined',
-      () => new DataIntegrityError('Expected login to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item.login !== null,
+    () => new DataIntegrityError('Expected login to be non-null')
+  );
+  assert(
+    typeof item.login !== 'undefined',
+    () => new DataIntegrityError('Expected login to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   const result: UserLogin = {
     createdAt: new Date(item._ct),

--- a/examples/existing-yml-schema/__generated__/actions.ts
+++ b/examples/existing-yml-schema/__generated__/actions.ts
@@ -79,6 +79,20 @@ export interface Node {
   id: Scalars['ID'];
 }
 
+/**
+ * Like Model, but includes a `publicId` field which, unline `id`, is semantically
+ * meaningless. Types implementing PublicModel will have an additional function,
+ * `queryByPublicId`, generated. If any of your models implement PublicModel, then
+ * the dependencies module must include an `idGenerator()`.
+ */
+export interface PublicModel {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  publicId: Scalars['String'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
 /** The Query type */
 export interface Query {
   __typename?: 'Query';

--- a/examples/existing-yml-schema/__generated__/actions.ts
+++ b/examples/existing-yml-schema/__generated__/actions.ts
@@ -725,76 +725,59 @@ export function marshallUserLogin(
 
 /** Unmarshalls a DynamoDB record into a UserLogin object */
 export function unmarshallUserLogin(item: Record<string, any>): UserLogin {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('login' in item) {
-    assert(
-      item.login !== null,
-      () => new DataIntegrityError('Expected login to be non-null')
-    );
-    assert(
-      typeof item.login !== 'undefined',
-      () => new DataIntegrityError('Expected login to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item.login !== null,
+    () => new DataIntegrityError('Expected login to be non-null')
+  );
+  assert(
+    typeof item.login !== 'undefined',
+    () => new DataIntegrityError('Expected login to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   const result: UserLogin = {
     createdAt: new Date(item._ct),

--- a/examples/real-world-complex-cdc/__generated__/actions.ts
+++ b/examples/real-world-complex-cdc/__generated__/actions.ts
@@ -1005,116 +1005,95 @@ export function marshallCaseInstance(
 export function unmarshallCaseInstance(
   item: Record<string, any>
 ): CaseInstance {
-  if ('branch_name' in item) {
-    assert(
-      item.branch_name !== null,
-      () => new DataIntegrityError('Expected branchName to be non-null')
-    );
-    assert(
-      typeof item.branch_name !== 'undefined',
-      () => new DataIntegrityError('Expected branchName to be defined')
-    );
-  }
-  if ('conclusion' in item) {
-    assert(
-      item.conclusion !== null,
-      () => new DataIntegrityError('Expected conclusion to be non-null')
-    );
-    assert(
-      typeof item.conclusion !== 'undefined',
-      () => new DataIntegrityError('Expected conclusion to be defined')
-    );
-  }
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('lineage' in item) {
-    assert(
-      item.lineage !== null,
-      () => new DataIntegrityError('Expected lineage to be non-null')
-    );
-    assert(
-      typeof item.lineage !== 'undefined',
-      () => new DataIntegrityError('Expected lineage to be defined')
-    );
-  }
-  if ('repo_id' in item) {
-    assert(
-      item.repo_id !== null,
-      () => new DataIntegrityError('Expected repoId to be non-null')
-    );
-    assert(
-      typeof item.repo_id !== 'undefined',
-      () => new DataIntegrityError('Expected repoId to be defined')
-    );
-  }
-  if ('retry' in item) {
-    assert(
-      item.retry !== null,
-      () => new DataIntegrityError('Expected retry to be non-null')
-    );
-    assert(
-      typeof item.retry !== 'undefined',
-      () => new DataIntegrityError('Expected retry to be defined')
-    );
-  }
-  if ('sha' in item) {
-    assert(
-      item.sha !== null,
-      () => new DataIntegrityError('Expected sha to be non-null')
-    );
-    assert(
-      typeof item.sha !== 'undefined',
-      () => new DataIntegrityError('Expected sha to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item.branch_name !== null,
+    () => new DataIntegrityError('Expected branchName to be non-null')
+  );
+  assert(
+    typeof item.branch_name !== 'undefined',
+    () => new DataIntegrityError('Expected branchName to be defined')
+  );
+
+  assert(
+    item.conclusion !== null,
+    () => new DataIntegrityError('Expected conclusion to be non-null')
+  );
+  assert(
+    typeof item.conclusion !== 'undefined',
+    () => new DataIntegrityError('Expected conclusion to be defined')
+  );
+
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.lineage !== null,
+    () => new DataIntegrityError('Expected lineage to be non-null')
+  );
+  assert(
+    typeof item.lineage !== 'undefined',
+    () => new DataIntegrityError('Expected lineage to be defined')
+  );
+
+  assert(
+    item.repo_id !== null,
+    () => new DataIntegrityError('Expected repoId to be non-null')
+  );
+  assert(
+    typeof item.repo_id !== 'undefined',
+    () => new DataIntegrityError('Expected repoId to be defined')
+  );
+
+  assert(
+    item.retry !== null,
+    () => new DataIntegrityError('Expected retry to be non-null')
+  );
+  assert(
+    typeof item.retry !== 'undefined',
+    () => new DataIntegrityError('Expected retry to be defined')
+  );
+
+  assert(
+    item.sha !== null,
+    () => new DataIntegrityError('Expected sha to be non-null')
+  );
+  assert(
+    typeof item.sha !== 'undefined',
+    () => new DataIntegrityError('Expected sha to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: CaseInstance = {
     branchName: item.branch_name,
@@ -1810,106 +1789,86 @@ export function marshallCaseSummary(
 
 /** Unmarshalls a DynamoDB record into a CaseSummary object */
 export function unmarshallCaseSummary(item: Record<string, any>): CaseSummary {
-  if ('branch_name' in item) {
-    assert(
-      item.branch_name !== null,
-      () => new DataIntegrityError('Expected branchName to be non-null')
-    );
-    assert(
-      typeof item.branch_name !== 'undefined',
-      () => new DataIntegrityError('Expected branchName to be defined')
-    );
-  }
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('duration' in item) {
-    assert(
-      item.duration !== null,
-      () => new DataIntegrityError('Expected duration to be non-null')
-    );
-    assert(
-      typeof item.duration !== 'undefined',
-      () => new DataIntegrityError('Expected duration to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('lineage' in item) {
-    assert(
-      item.lineage !== null,
-      () => new DataIntegrityError('Expected lineage to be non-null')
-    );
-    assert(
-      typeof item.lineage !== 'undefined',
-      () => new DataIntegrityError('Expected lineage to be defined')
-    );
-  }
-  if ('repo_id' in item) {
-    assert(
-      item.repo_id !== null,
-      () => new DataIntegrityError('Expected repoId to be non-null')
-    );
-    assert(
-      typeof item.repo_id !== 'undefined',
-      () => new DataIntegrityError('Expected repoId to be defined')
-    );
-  }
-  if ('stability' in item) {
-    assert(
-      item.stability !== null,
-      () => new DataIntegrityError('Expected stability to be non-null')
-    );
-    assert(
-      typeof item.stability !== 'undefined',
-      () => new DataIntegrityError('Expected stability to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item.branch_name !== null,
+    () => new DataIntegrityError('Expected branchName to be non-null')
+  );
+  assert(
+    typeof item.branch_name !== 'undefined',
+    () => new DataIntegrityError('Expected branchName to be defined')
+  );
+
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.duration !== null,
+    () => new DataIntegrityError('Expected duration to be non-null')
+  );
+  assert(
+    typeof item.duration !== 'undefined',
+    () => new DataIntegrityError('Expected duration to be defined')
+  );
+
+  assert(
+    item.lineage !== null,
+    () => new DataIntegrityError('Expected lineage to be non-null')
+  );
+  assert(
+    typeof item.lineage !== 'undefined',
+    () => new DataIntegrityError('Expected lineage to be defined')
+  );
+
+  assert(
+    item.repo_id !== null,
+    () => new DataIntegrityError('Expected repoId to be non-null')
+  );
+  assert(
+    typeof item.repo_id !== 'undefined',
+    () => new DataIntegrityError('Expected repoId to be defined')
+  );
+
+  assert(
+    item.stability !== null,
+    () => new DataIntegrityError('Expected stability to be non-null')
+  );
+  assert(
+    typeof item.stability !== 'undefined',
+    () => new DataIntegrityError('Expected stability to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: CaseSummary = {
     branchName: item.branch_name,
@@ -2584,96 +2543,77 @@ export function marshallFileTiming(
 
 /** Unmarshalls a DynamoDB record into a FileTiming object */
 export function unmarshallFileTiming(item: Record<string, any>): FileTiming {
-  if ('branch_name' in item) {
-    assert(
-      item.branch_name !== null,
-      () => new DataIntegrityError('Expected branchName to be non-null')
-    );
-    assert(
-      typeof item.branch_name !== 'undefined',
-      () => new DataIntegrityError('Expected branchName to be defined')
-    );
-  }
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('duration' in item) {
-    assert(
-      item.duration !== null,
-      () => new DataIntegrityError('Expected duration to be non-null')
-    );
-    assert(
-      typeof item.duration !== 'undefined',
-      () => new DataIntegrityError('Expected duration to be defined')
-    );
-  }
-  if ('filename' in item) {
-    assert(
-      item.filename !== null,
-      () => new DataIntegrityError('Expected filename to be non-null')
-    );
-    assert(
-      typeof item.filename !== 'undefined',
-      () => new DataIntegrityError('Expected filename to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('repo_id' in item) {
-    assert(
-      item.repo_id !== null,
-      () => new DataIntegrityError('Expected repoId to be non-null')
-    );
-    assert(
-      typeof item.repo_id !== 'undefined',
-      () => new DataIntegrityError('Expected repoId to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item.branch_name !== null,
+    () => new DataIntegrityError('Expected branchName to be non-null')
+  );
+  assert(
+    typeof item.branch_name !== 'undefined',
+    () => new DataIntegrityError('Expected branchName to be defined')
+  );
+
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.duration !== null,
+    () => new DataIntegrityError('Expected duration to be non-null')
+  );
+  assert(
+    typeof item.duration !== 'undefined',
+    () => new DataIntegrityError('Expected duration to be defined')
+  );
+
+  assert(
+    item.filename !== null,
+    () => new DataIntegrityError('Expected filename to be non-null')
+  );
+  assert(
+    typeof item.filename !== 'undefined',
+    () => new DataIntegrityError('Expected filename to be defined')
+  );
+
+  assert(
+    item.repo_id !== null,
+    () => new DataIntegrityError('Expected repoId to be non-null')
+  );
+  assert(
+    typeof item.repo_id !== 'undefined',
+    () => new DataIntegrityError('Expected repoId to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: FileTiming = {
     branchName: item.branch_name,

--- a/examples/real-world-complex-cdc/__generated__/actions.ts
+++ b/examples/real-world-complex-cdc/__generated__/actions.ts
@@ -135,6 +135,20 @@ export interface Node {
   id: Scalars['ID'];
 }
 
+/**
+ * Like Model, but includes a `publicId` field which, unline `id`, is semantically
+ * meaningless. Types implementing PublicModel will have an additional function,
+ * `queryByPublicId`, generated. If any of your models implement PublicModel, then
+ * the dependencies module must include an `idGenerator()`.
+ */
+export interface PublicModel {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  publicId: Scalars['String'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
 /** Not used. Just here to satisfy ESLint. */
 export interface Query {
   __typename?: 'Query';

--- a/examples/schema-directives/__generated__/actions.ts
+++ b/examples/schema-directives/__generated__/actions.ts
@@ -585,66 +585,50 @@ export function marshallUserSession(
 
 /** Unmarshalls a DynamoDB record into a UserSession object */
 export function unmarshallUserSession(item: Record<string, any>): UserSession {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('session' in item) {
-    assert(
-      item.session !== null,
-      () => new DataIntegrityError('Expected session to be non-null')
-    );
-    assert(
-      typeof item.session !== 'undefined',
-      () => new DataIntegrityError('Expected session to be defined')
-    );
-  }
-  if ('session_id' in item) {
-    assert(
-      item.session_id !== null,
-      () => new DataIntegrityError('Expected sessionId to be non-null')
-    );
-    assert(
-      typeof item.session_id !== 'undefined',
-      () => new DataIntegrityError('Expected sessionId to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.session !== null,
+    () => new DataIntegrityError('Expected session to be non-null')
+  );
+  assert(
+    typeof item.session !== 'undefined',
+    () => new DataIntegrityError('Expected session to be defined')
+  );
+
+  assert(
+    item.session_id !== null,
+    () => new DataIntegrityError('Expected sessionId to be non-null')
+  );
+  assert(
+    typeof item.session_id !== 'undefined',
+    () => new DataIntegrityError('Expected sessionId to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: UserSession = {
     createdAt: new Date(item._ct),

--- a/examples/schema-directives/__generated__/template.yml
+++ b/examples/schema-directives/__generated__/template.yml
@@ -40,13 +40,13 @@ Resources:
       AttributeDefinitions:
         - AttributeName: pk
           AttributeType: S
-        - AttributeName: publicIdpk
+        - AttributeName: publicId
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
       GlobalSecondaryIndexes:
         - IndexName: publicId
           KeySchema:
-            - AttributeName: publicIdpk
+            - AttributeName: publicId
               KeyType: HASH
           Projection:
             ProjectionType: ALL

--- a/examples/schema-directives/__generated__/template.yml
+++ b/examples/schema-directives/__generated__/template.yml
@@ -40,7 +40,16 @@ Resources:
       AttributeDefinitions:
         - AttributeName: pk
           AttributeType: S
+        - AttributeName: publicIdpk
+          AttributeType: S
       BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: publicId
+          KeySchema:
+            - AttributeName: publicIdpk
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
       KeySchema:
         - AttributeName: pk
           KeyType: HASH

--- a/examples/schema-directives/schema-directives.test.ts
+++ b/examples/schema-directives/schema-directives.test.ts
@@ -16,6 +16,7 @@ import {
 
 const userSessionMatcher = {
   createdAt: expect.any(Date),
+  publicId: expect.any(String),
   updatedAt: expect.any(Date),
 };
 
@@ -41,8 +42,14 @@ describe('optionalFields', () => {
         `
         {
           "capacity": {
-            "CapacityUnits": 1,
-            "GlobalSecondaryIndexes": undefined,
+            "CapacityUnits": 2,
+            "GlobalSecondaryIndexes": {
+              "publicId": {
+                "CapacityUnits": 1,
+                "ReadCapacityUnits": undefined,
+                "WriteCapacityUnits": undefined,
+              },
+            },
             "LocalSecondaryIndexes": undefined,
             "ReadCapacityUnits": undefined,
             "Table": {
@@ -56,6 +63,7 @@ describe('optionalFields', () => {
           "item": {
             "createdAt": Any<Date>,
             "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+            "publicId": Any<String>,
             "session": {
               "foo": "foo",
             },
@@ -78,8 +86,14 @@ describe('optionalFields', () => {
         `
         {
           "capacity": {
-            "CapacityUnits": 1,
-            "GlobalSecondaryIndexes": undefined,
+            "CapacityUnits": 2,
+            "GlobalSecondaryIndexes": {
+              "publicId": {
+                "CapacityUnits": 1,
+                "ReadCapacityUnits": undefined,
+                "WriteCapacityUnits": undefined,
+              },
+            },
             "LocalSecondaryIndexes": undefined,
             "ReadCapacityUnits": undefined,
             "Table": {
@@ -93,6 +107,7 @@ describe('optionalFields', () => {
           "item": {
             "createdAt": Any<Date>,
             "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+            "publicId": Any<String>,
             "session": {
               "foo": "bar",
             },
@@ -127,6 +142,7 @@ describe('optionalFields', () => {
           "item": {
             "createdAt": Any<Date>,
             "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+            "publicId": Any<String>,
             "session": {
               "foo": "bar",
             },
@@ -161,8 +177,14 @@ describe('optional ttl', () => {
       `
       {
         "capacity": {
-          "CapacityUnits": 1,
-          "GlobalSecondaryIndexes": undefined,
+          "CapacityUnits": 2,
+          "GlobalSecondaryIndexes": {
+            "publicId": {
+              "CapacityUnits": 1,
+              "ReadCapacityUnits": undefined,
+              "WriteCapacityUnits": undefined,
+            },
+          },
           "LocalSecondaryIndexes": undefined,
           "ReadCapacityUnits": undefined,
           "Table": {
@@ -176,6 +198,7 @@ describe('optional ttl', () => {
         "item": {
           "createdAt": Any<Date>,
           "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+          "publicId": Any<String>,
           "session": {
             "foo": "foo",
           },
@@ -212,8 +235,14 @@ describe('optional ttl', () => {
       `
       {
         "capacity": {
-          "CapacityUnits": 1,
-          "GlobalSecondaryIndexes": undefined,
+          "CapacityUnits": 2,
+          "GlobalSecondaryIndexes": {
+            "publicId": {
+              "CapacityUnits": 1,
+              "ReadCapacityUnits": undefined,
+              "WriteCapacityUnits": undefined,
+            },
+          },
           "LocalSecondaryIndexes": undefined,
           "ReadCapacityUnits": undefined,
           "Table": {
@@ -228,6 +257,7 @@ describe('optional ttl', () => {
           "createdAt": Any<Date>,
           "expires": Any<Date>,
           "id": "VXNlclNlc3Npb246VVNFUl9TRVNTSU9OIzE4MWM4ODdjLWU3ZGYtNDMzMS05ZmJhLTY1ZDI1NTg2N2UyMA",
+          "publicId": Any<String>,
           "session": {
             "foo": "foo",
           },

--- a/examples/schema-directives/schema-directives.test.ts
+++ b/examples/schema-directives/schema-directives.test.ts
@@ -255,7 +255,7 @@ describe('optional ttl', () => {
 describe('@alias', () => {
   it("changes field's column name", async () => {
     async function loadRaw(sessionId: string) {
-      const {ConsumedCapacity: capacity, Item: item} = await ddbDocClient.send(
+      const {Item: item} = await ddbDocClient.send(
         new GetCommand({
           ConsistentRead: true,
           Key: {pk: `USER_SESSION#${sessionId}`},

--- a/examples/schema-directives/schema-directives.test.ts
+++ b/examples/schema-directives/schema-directives.test.ts
@@ -9,6 +9,7 @@ import {ddbDocClient} from '../dependencies';
 import {
   createUserSession,
   deleteUserSession,
+  queryUserSessionByPublicId,
   readUserSession,
   updateUserSession,
 } from './__generated__/actions';
@@ -290,5 +291,26 @@ describe('@alias', () => {
 
     const readResult2 = await readUserSession(createResult.item);
     expect(readResult2.item.aliasedField).toBe('bar');
+
+    // cleanup, not part of test
+    await deleteUserSession(createResult.item);
+  });
+});
+
+describe('PublicModel', () => {
+  it('can be queried by public id', async () => {
+    const result = await createUserSession({
+      session: {foo: 'foo'},
+      sessionId: faker.datatype.uuid(),
+    });
+
+    const queriedResult = await queryUserSessionByPublicId(
+      result.item.publicId
+    );
+
+    expect(queriedResult.item).toStrictEqual(result.item);
+
+    // cleanup, not part of test
+    await deleteUserSession(result.item);
   });
 });

--- a/examples/schema-directives/schema/user-session.graphqls
+++ b/examples/schema-directives/schema/user-session.graphqls
@@ -1,7 +1,7 @@
 """
 A user session object.
 """
-type UserSession implements Model & Node & Timestamped & Versioned
+type UserSession implements PublicModel & Model & Node & Timestamped & Versioned
   @consistent
   @partitionKey(pkFields: ["sessionId"], pkPrefix: "USER_SESSION")
   @table(
@@ -12,6 +12,7 @@ type UserSession implements Model & Node & Timestamped & Versioned
   createdAt: Date!
   expires: Date @ttl
   id: ID!
+  publicId: String!
   """
   Since `id` is a reserved field, sessionId is the field we'll use to inject a
   random uuid, which the underlying system will use as the basis for `id`.

--- a/examples/single-table-design/__generated__/actions.ts
+++ b/examples/single-table-design/__generated__/actions.ts
@@ -577,45 +577,66 @@ export type QueryAccountInput =
 export type QueryAccountOutput = MultiResultType<Account>;
 
 /** helper */
-function makePartitionKeyForQueryAccount(input: QueryAccountInput): string {
-  if (!('index' in input)) {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
-  } else if ('index' in input && input.index === 'lsi1') {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
-  }
-
-  throw new Error('Could not construct partition key from input');
-}
-
-/** helper */
-function makeSortKeyForQueryAccount(
+function makeEanForQueryAccount(
   input: QueryAccountInput
-): string | undefined {
+): Record<string, string> {
   if ('index' in input) {
     if (input.index === 'lsi1') {
-      return ['INSTANCE', 'createdAt' in input && input.createdAt]
-        .filter(Boolean)
-        .join('#');
+      return {'#pk': 'pk', '#sk': 'sk'};
     }
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
   } else {
-    return ['SUMMARY'].filter(Boolean).join('#');
+    return {'#pk': 'pk', '#sk': 'sk'};
   }
 }
 
 /** helper */
-function makeEavPkForQueryAccount(input: QueryAccountInput): string {
-  return 'pk';
-}
-
-/** helper */
-function makeEavSkForQueryAccount(input: QueryAccountInput): string {
+function makeEavForQueryAccount(input: QueryAccountInput): Record<string, any> {
   if ('index' in input) {
-    const lsis = ['lsi1'];
-    if (lsis.includes(input.index)) {
-      return input.index;
+    if (input.index === 'lsi1') {
+      return {
+        ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+        ':sk': ['INSTANCE', 'createdAt' in input && input.createdAt]
+          .filter(Boolean)
+          .join('#'),
+      };
     }
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {
+      ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+      ':sk': ['SUMMARY'].filter(Boolean).join('#'),
+    };
   }
-  return 'sk';
+}
+
+/** helper */
+function makeKceForQueryAccount(
+  input: QueryAccountInput,
+  {operator}: Pick<QueryOptions, 'operator'>
+): string {
+  if ('index' in input) {
+    if (input.index === 'lsi1') {
+      return `#pk = :pk AND ${
+        operator === 'begins_with'
+          ? 'begins_with(#sk, :sk)'
+          : `#sk ${operator} :sk`
+      }`;
+    }
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return `#pk = :pk AND ${
+      operator === 'begins_with'
+        ? 'begins_with(#sk, :sk)'
+        : `#sk ${operator} :sk`
+    }`;
+  }
 }
 
 /** queryAccount */
@@ -630,24 +651,18 @@ export async function queryAccount(
   const tableName = process.env.TABLE_ACCOUNTS;
   assert(tableName, 'TABLE_ACCOUNTS is not set');
 
+  const ExpressionAttributeNames = makeEanForQueryAccount(input);
+  const ExpressionAttributeValues = makeEavForQueryAccount(input);
+  const KeyConditionExpression = makeKceForQueryAccount(input, {operator});
+
   const {ConsumedCapacity: capacity, Items: items = []} =
     await ddbDocClient.send(
       new QueryCommand({
         ConsistentRead: false,
-        ExpressionAttributeNames: {
-          '#pk': makeEavPkForQueryAccount(input),
-          '#sk': makeEavSkForQueryAccount(input),
-        },
-        ExpressionAttributeValues: {
-          ':pk': makePartitionKeyForQueryAccount(input),
-          ':sk': makeSortKeyForQueryAccount(input),
-        },
+        ExpressionAttributeNames,
+        ExpressionAttributeValues,
         IndexName: 'index' in input ? input.index : undefined,
-        KeyConditionExpression: `#pk = :pk AND ${
-          operator === 'begins_with'
-            ? 'begins_with(#sk, :sk)'
-            : `#sk ${operator} :sk`
-        }`,
+        KeyConditionExpression,
         Limit: limit,
         ReturnConsumedCapacity: 'INDEXES',
         ScanIndexForward: !reverse,
@@ -1261,37 +1276,52 @@ export type QueryScheduledEmailInput =
 export type QueryScheduledEmailOutput = MultiResultType<ScheduledEmail>;
 
 /** helper */
-function makePartitionKeyForQueryScheduledEmail(
+function makeEanForQueryScheduledEmail(
   input: QueryScheduledEmailInput
-): string {
-  if (!('index' in input)) {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+): Record<string, string> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {'#pk': 'pk', '#sk': 'sk'};
   }
-
-  throw new Error('Could not construct partition key from input');
 }
 
 /** helper */
-function makeSortKeyForQueryScheduledEmail(
+function makeEavForQueryScheduledEmail(
   input: QueryScheduledEmailInput
-): string | undefined {
-  return ['SCHEDULED_EMAIL', 'template' in input && input.template]
-    .filter(Boolean)
-    .join('#');
+): Record<string, any> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {
+      ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+      ':sk': ['SCHEDULED_EMAIL', 'template' in input && input.template]
+        .filter(Boolean)
+        .join('#'),
+    };
+  }
 }
 
 /** helper */
-function makeEavPkForQueryScheduledEmail(
-  input: QueryScheduledEmailInput
+function makeKceForQueryScheduledEmail(
+  input: QueryScheduledEmailInput,
+  {operator}: Pick<QueryOptions, 'operator'>
 ): string {
-  return 'pk';
-}
-
-/** helper */
-function makeEavSkForQueryScheduledEmail(
-  input: QueryScheduledEmailInput
-): string {
-  return 'sk';
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return `#pk = :pk AND ${
+      operator === 'begins_with'
+        ? 'begins_with(#sk, :sk)'
+        : `#sk ${operator} :sk`
+    }`;
+  }
 }
 
 /** queryScheduledEmail */
@@ -1306,24 +1336,20 @@ export async function queryScheduledEmail(
   const tableName = process.env.TABLE_EMAIL;
   assert(tableName, 'TABLE_EMAIL is not set');
 
+  const ExpressionAttributeNames = makeEanForQueryScheduledEmail(input);
+  const ExpressionAttributeValues = makeEavForQueryScheduledEmail(input);
+  const KeyConditionExpression = makeKceForQueryScheduledEmail(input, {
+    operator,
+  });
+
   const {ConsumedCapacity: capacity, Items: items = []} =
     await ddbDocClient.send(
       new QueryCommand({
         ConsistentRead: false,
-        ExpressionAttributeNames: {
-          '#pk': makeEavPkForQueryScheduledEmail(input),
-          '#sk': makeEavSkForQueryScheduledEmail(input),
-        },
-        ExpressionAttributeValues: {
-          ':pk': makePartitionKeyForQueryScheduledEmail(input),
-          ':sk': makeSortKeyForQueryScheduledEmail(input),
-        },
+        ExpressionAttributeNames,
+        ExpressionAttributeValues,
         IndexName: undefined,
-        KeyConditionExpression: `#pk = :pk AND ${
-          operator === 'begins_with'
-            ? 'begins_with(#sk, :sk)'
-            : `#sk ${operator} :sk`
-        }`,
+        KeyConditionExpression,
         Limit: limit,
         ReturnConsumedCapacity: 'INDEXES',
         ScanIndexForward: !reverse,
@@ -1928,35 +1954,56 @@ export type QuerySentEmailInput =
 export type QuerySentEmailOutput = MultiResultType<SentEmail>;
 
 /** helper */
-function makePartitionKeyForQuerySentEmail(input: QuerySentEmailInput): string {
-  if (!('index' in input)) {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
-  }
-
-  throw new Error('Could not construct partition key from input');
-}
-
-/** helper */
-function makeSortKeyForQuerySentEmail(
+function makeEanForQuerySentEmail(
   input: QuerySentEmailInput
-): string | undefined {
-  return [
-    'TEMPLATE',
-    'template' in input && input.template,
-    'createdAt' in input && input.createdAt,
-  ]
-    .filter(Boolean)
-    .join('#');
+): Record<string, string> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {'#pk': 'pk', '#sk': 'sk'};
+  }
 }
 
 /** helper */
-function makeEavPkForQuerySentEmail(input: QuerySentEmailInput): string {
-  return 'pk';
+function makeEavForQuerySentEmail(
+  input: QuerySentEmailInput
+): Record<string, any> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {
+      ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+      ':sk': [
+        'TEMPLATE',
+        'template' in input && input.template,
+        'createdAt' in input && input.createdAt,
+      ]
+        .filter(Boolean)
+        .join('#'),
+    };
+  }
 }
 
 /** helper */
-function makeEavSkForQuerySentEmail(input: QuerySentEmailInput): string {
-  return 'sk';
+function makeKceForQuerySentEmail(
+  input: QuerySentEmailInput,
+  {operator}: Pick<QueryOptions, 'operator'>
+): string {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return `#pk = :pk AND ${
+      operator === 'begins_with'
+        ? 'begins_with(#sk, :sk)'
+        : `#sk ${operator} :sk`
+    }`;
+  }
 }
 
 /** querySentEmail */
@@ -1971,24 +2018,18 @@ export async function querySentEmail(
   const tableName = process.env.TABLE_EMAIL;
   assert(tableName, 'TABLE_EMAIL is not set');
 
+  const ExpressionAttributeNames = makeEanForQuerySentEmail(input);
+  const ExpressionAttributeValues = makeEavForQuerySentEmail(input);
+  const KeyConditionExpression = makeKceForQuerySentEmail(input, {operator});
+
   const {ConsumedCapacity: capacity, Items: items = []} =
     await ddbDocClient.send(
       new QueryCommand({
         ConsistentRead: false,
-        ExpressionAttributeNames: {
-          '#pk': makeEavPkForQuerySentEmail(input),
-          '#sk': makeEavSkForQuerySentEmail(input),
-        },
-        ExpressionAttributeValues: {
-          ':pk': makePartitionKeyForQuerySentEmail(input),
-          ':sk': makeSortKeyForQuerySentEmail(input),
-        },
+        ExpressionAttributeNames,
+        ExpressionAttributeValues,
         IndexName: undefined,
-        KeyConditionExpression: `#pk = :pk AND ${
-          operator === 'begins_with'
-            ? 'begins_with(#sk, :sk)'
-            : `#sk ${operator} :sk`
-        }`,
+        KeyConditionExpression,
         Limit: limit,
         ReturnConsumedCapacity: 'INDEXES',
         ScanIndexForward: !reverse,
@@ -2580,33 +2621,52 @@ export type QuerySubscriptionInput =
 export type QuerySubscriptionOutput = MultiResultType<Subscription>;
 
 /** helper */
-function makePartitionKeyForQuerySubscription(
+function makeEanForQuerySubscription(
   input: QuerySubscriptionInput
-): string {
-  if (!('index' in input)) {
-    return `ACCOUNT#${input.vendor}#${input.externalId}`;
+): Record<string, string> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {'#pk': 'pk', '#sk': 'sk'};
   }
-
-  throw new Error('Could not construct partition key from input');
 }
 
 /** helper */
-function makeSortKeyForQuerySubscription(
+function makeEavForQuerySubscription(
   input: QuerySubscriptionInput
-): string | undefined {
-  return ['SUBSCRIPTION', 'effectiveDate' in input && input.effectiveDate]
-    .filter(Boolean)
-    .join('#');
+): Record<string, any> {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return {
+      ':pk': `ACCOUNT#${input.vendor}#${input.externalId}`,
+      ':sk': ['SUBSCRIPTION', 'effectiveDate' in input && input.effectiveDate]
+        .filter(Boolean)
+        .join('#'),
+    };
+  }
 }
 
 /** helper */
-function makeEavPkForQuerySubscription(input: QuerySubscriptionInput): string {
-  return 'pk';
-}
-
-/** helper */
-function makeEavSkForQuerySubscription(input: QuerySubscriptionInput): string {
-  return 'sk';
+function makeKceForQuerySubscription(
+  input: QuerySubscriptionInput,
+  {operator}: Pick<QueryOptions, 'operator'>
+): string {
+  if ('index' in input) {
+    throw new Error(
+      'Invalid index. If TypeScript did not catch this, then this is a bug in codegen.'
+    );
+  } else {
+    return `#pk = :pk AND ${
+      operator === 'begins_with'
+        ? 'begins_with(#sk, :sk)'
+        : `#sk ${operator} :sk`
+    }`;
+  }
 }
 
 /** querySubscription */
@@ -2621,24 +2681,18 @@ export async function querySubscription(
   const tableName = process.env.TABLE_ACCOUNTS;
   assert(tableName, 'TABLE_ACCOUNTS is not set');
 
+  const ExpressionAttributeNames = makeEanForQuerySubscription(input);
+  const ExpressionAttributeValues = makeEavForQuerySubscription(input);
+  const KeyConditionExpression = makeKceForQuerySubscription(input, {operator});
+
   const {ConsumedCapacity: capacity, Items: items = []} =
     await ddbDocClient.send(
       new QueryCommand({
         ConsistentRead: false,
-        ExpressionAttributeNames: {
-          '#pk': makeEavPkForQuerySubscription(input),
-          '#sk': makeEavSkForQuerySubscription(input),
-        },
-        ExpressionAttributeValues: {
-          ':pk': makePartitionKeyForQuerySubscription(input),
-          ':sk': makeSortKeyForQuerySubscription(input),
-        },
+        ExpressionAttributeNames,
+        ExpressionAttributeValues,
         IndexName: undefined,
-        KeyConditionExpression: `#pk = :pk AND ${
-          operator === 'begins_with'
-            ? 'begins_with(#sk, :sk)'
-            : `#sk ${operator} :sk`
-        }`,
+        KeyConditionExpression,
         Limit: limit,
         ReturnConsumedCapacity: 'INDEXES',
         ScanIndexForward: !reverse,

--- a/examples/single-table-design/__generated__/actions.ts
+++ b/examples/single-table-design/__generated__/actions.ts
@@ -770,76 +770,59 @@ export function marshallAccount(
 
 /** Unmarshalls a DynamoDB record into a Account object */
 export function unmarshallAccount(item: Record<string, any>): Account {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('effective_date' in item) {
-    assert(
-      item.effective_date !== null,
-      () => new DataIntegrityError('Expected effectiveDate to be non-null')
-    );
-    assert(
-      typeof item.effective_date !== 'undefined',
-      () => new DataIntegrityError('Expected effectiveDate to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.effective_date !== null,
+    () => new DataIntegrityError('Expected effectiveDate to be non-null')
+  );
+  assert(
+    typeof item.effective_date !== 'undefined',
+    () => new DataIntegrityError('Expected effectiveDate to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: Account = {
     createdAt: new Date(item._ct),
@@ -1471,76 +1454,59 @@ export function marshallScheduledEmail(
 export function unmarshallScheduledEmail(
   item: Record<string, any>
 ): ScheduledEmail {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('template' in item) {
-    assert(
-      item.template !== null,
-      () => new DataIntegrityError('Expected template to be non-null')
-    );
-    assert(
-      typeof item.template !== 'undefined',
-      () => new DataIntegrityError('Expected template to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item.template !== null,
+    () => new DataIntegrityError('Expected template to be non-null')
+  );
+  assert(
+    typeof item.template !== 'undefined',
+    () => new DataIntegrityError('Expected template to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: ScheduledEmail = {
     createdAt: new Date(item._ct),
@@ -2140,86 +2106,68 @@ export function marshallSentEmail(
 
 /** Unmarshalls a DynamoDB record into a SentEmail object */
 export function unmarshallSentEmail(item: Record<string, any>): SentEmail {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('message_id' in item) {
-    assert(
-      item.message_id !== null,
-      () => new DataIntegrityError('Expected messageId to be non-null')
-    );
-    assert(
-      typeof item.message_id !== 'undefined',
-      () => new DataIntegrityError('Expected messageId to be defined')
-    );
-  }
-  if ('template' in item) {
-    assert(
-      item.template !== null,
-      () => new DataIntegrityError('Expected template to be non-null')
-    );
-    assert(
-      typeof item.template !== 'undefined',
-      () => new DataIntegrityError('Expected template to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item.message_id !== null,
+    () => new DataIntegrityError('Expected messageId to be non-null')
+  );
+  assert(
+    typeof item.message_id !== 'undefined',
+    () => new DataIntegrityError('Expected messageId to be defined')
+  );
+
+  assert(
+    item.template !== null,
+    () => new DataIntegrityError('Expected template to be non-null')
+  );
+  assert(
+    typeof item.template !== 'undefined',
+    () => new DataIntegrityError('Expected template to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   const result: SentEmail = {
     createdAt: new Date(item._ct),
@@ -2820,76 +2768,59 @@ export function marshallSubscription(
 export function unmarshallSubscription(
   item: Record<string, any>
 ): Subscription {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('effective_date' in item) {
-    assert(
-      item.effective_date !== null,
-      () => new DataIntegrityError('Expected effectiveDate to be non-null')
-    );
-    assert(
-      typeof item.effective_date !== 'undefined',
-      () => new DataIntegrityError('Expected effectiveDate to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.effective_date !== null,
+    () => new DataIntegrityError('Expected effectiveDate to be non-null')
+  );
+  assert(
+    typeof item.effective_date !== 'undefined',
+    () => new DataIntegrityError('Expected effectiveDate to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   let result: Subscription = {
     createdAt: new Date(item._ct),

--- a/examples/single-table-design/__generated__/actions.ts
+++ b/examples/single-table-design/__generated__/actions.ts
@@ -100,6 +100,20 @@ export interface Node {
 /** The available plans. */
 export type PlanName = 'ENTERPRISE' | 'OPEN_SOURCE' | 'SMALL_TEAM';
 
+/**
+ * Like Model, but includes a `publicId` field which, unline `id`, is semantically
+ * meaningless. Types implementing PublicModel will have an additional function,
+ * `queryByPublicId`, generated. If any of your models implement PublicModel, then
+ * the dependencies module must include an `idGenerator()`.
+ */
+export interface PublicModel {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  publicId: Scalars['String'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
 /** The Query type */
 export interface Query {
   __typename?: 'Query';

--- a/examples/user-login/__generated__/actions.ts
+++ b/examples/user-login/__generated__/actions.ts
@@ -79,6 +79,20 @@ export interface Node {
   id: Scalars['ID'];
 }
 
+/**
+ * Like Model, but includes a `publicId` field which, unline `id`, is semantically
+ * meaningless. Types implementing PublicModel will have an additional function,
+ * `queryByPublicId`, generated. If any of your models implement PublicModel, then
+ * the dependencies module must include an `idGenerator()`.
+ */
+export interface PublicModel {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  publicId: Scalars['String'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
 /** The Query type */
 export interface Query {
   __typename?: 'Query';

--- a/examples/user-login/__generated__/actions.ts
+++ b/examples/user-login/__generated__/actions.ts
@@ -725,76 +725,59 @@ export function marshallUserLogin(
 
 /** Unmarshalls a DynamoDB record into a UserLogin object */
 export function unmarshallUserLogin(item: Record<string, any>): UserLogin {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('external_id' in item) {
-    assert(
-      item.external_id !== null,
-      () => new DataIntegrityError('Expected externalId to be non-null')
-    );
-    assert(
-      typeof item.external_id !== 'undefined',
-      () => new DataIntegrityError('Expected externalId to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('login' in item) {
-    assert(
-      item.login !== null,
-      () => new DataIntegrityError('Expected login to be non-null')
-    );
-    assert(
-      typeof item.login !== 'undefined',
-      () => new DataIntegrityError('Expected login to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('vendor' in item) {
-    assert(
-      item.vendor !== null,
-      () => new DataIntegrityError('Expected vendor to be non-null')
-    );
-    assert(
-      typeof item.vendor !== 'undefined',
-      () => new DataIntegrityError('Expected vendor to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.external_id !== null,
+    () => new DataIntegrityError('Expected externalId to be non-null')
+  );
+  assert(
+    typeof item.external_id !== 'undefined',
+    () => new DataIntegrityError('Expected externalId to be defined')
+  );
+
+  assert(
+    item.login !== null,
+    () => new DataIntegrityError('Expected login to be non-null')
+  );
+  assert(
+    typeof item.login !== 'undefined',
+    () => new DataIntegrityError('Expected login to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item.vendor !== null,
+    () => new DataIntegrityError('Expected vendor to be non-null')
+  );
+  assert(
+    typeof item.vendor !== 'undefined',
+    () => new DataIntegrityError('Expected vendor to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   const result: UserLogin = {
     createdAt: new Date(item._ct),

--- a/examples/user-session/__generated__/actions.ts
+++ b/examples/user-session/__generated__/actions.ts
@@ -79,6 +79,20 @@ export interface Node {
   id: Scalars['ID'];
 }
 
+/**
+ * Like Model, but includes a `publicId` field which, unline `id`, is semantically
+ * meaningless. Types implementing PublicModel will have an additional function,
+ * `queryByPublicId`, generated. If any of your models implement PublicModel, then
+ * the dependencies module must include an `idGenerator()`.
+ */
+export interface PublicModel {
+  createdAt: Scalars['Date'];
+  id: Scalars['ID'];
+  publicId: Scalars['String'];
+  updatedAt: Scalars['Date'];
+  version: Scalars['Int'];
+}
+
 /** The Query type */
 export interface Query {
   __typename?: 'Query';

--- a/examples/user-session/__generated__/actions.ts
+++ b/examples/user-session/__generated__/actions.ts
@@ -572,76 +572,59 @@ export function marshallUserSession(
 
 /** Unmarshalls a DynamoDB record into a UserSession object */
 export function unmarshallUserSession(item: Record<string, any>): UserSession {
-  if ('_ct' in item) {
-    assert(
-      item._ct !== null,
-      () => new DataIntegrityError('Expected createdAt to be non-null')
-    );
-    assert(
-      typeof item._ct !== 'undefined',
-      () => new DataIntegrityError('Expected createdAt to be defined')
-    );
-  }
-  if ('ttl' in item) {
-    assert(
-      item.ttl !== null,
-      () => new DataIntegrityError('Expected expires to be non-null')
-    );
-    assert(
-      typeof item.ttl !== 'undefined',
-      () => new DataIntegrityError('Expected expires to be defined')
-    );
-  }
-  if ('id' in item) {
-    assert(
-      item.id !== null,
-      () => new DataIntegrityError('Expected id to be non-null')
-    );
-    assert(
-      typeof item.id !== 'undefined',
-      () => new DataIntegrityError('Expected id to be defined')
-    );
-  }
-  if ('session' in item) {
-    assert(
-      item.session !== null,
-      () => new DataIntegrityError('Expected session to be non-null')
-    );
-    assert(
-      typeof item.session !== 'undefined',
-      () => new DataIntegrityError('Expected session to be defined')
-    );
-  }
-  if ('session_id' in item) {
-    assert(
-      item.session_id !== null,
-      () => new DataIntegrityError('Expected sessionId to be non-null')
-    );
-    assert(
-      typeof item.session_id !== 'undefined',
-      () => new DataIntegrityError('Expected sessionId to be defined')
-    );
-  }
-  if ('_md' in item) {
-    assert(
-      item._md !== null,
-      () => new DataIntegrityError('Expected updatedAt to be non-null')
-    );
-    assert(
-      typeof item._md !== 'undefined',
-      () => new DataIntegrityError('Expected updatedAt to be defined')
-    );
-  }
-  if ('_v' in item) {
-    assert(
-      item._v !== null,
-      () => new DataIntegrityError('Expected version to be non-null')
-    );
-    assert(
-      typeof item._v !== 'undefined',
-      () => new DataIntegrityError('Expected version to be defined')
-    );
-  }
+  assert(
+    item._ct !== null,
+    () => new DataIntegrityError('Expected createdAt to be non-null')
+  );
+  assert(
+    typeof item._ct !== 'undefined',
+    () => new DataIntegrityError('Expected createdAt to be defined')
+  );
+
+  assert(
+    item.ttl !== null,
+    () => new DataIntegrityError('Expected expires to be non-null')
+  );
+  assert(
+    typeof item.ttl !== 'undefined',
+    () => new DataIntegrityError('Expected expires to be defined')
+  );
+
+  assert(
+    item.session !== null,
+    () => new DataIntegrityError('Expected session to be non-null')
+  );
+  assert(
+    typeof item.session !== 'undefined',
+    () => new DataIntegrityError('Expected session to be defined')
+  );
+
+  assert(
+    item.session_id !== null,
+    () => new DataIntegrityError('Expected sessionId to be non-null')
+  );
+  assert(
+    typeof item.session_id !== 'undefined',
+    () => new DataIntegrityError('Expected sessionId to be defined')
+  );
+
+  assert(
+    item._md !== null,
+    () => new DataIntegrityError('Expected updatedAt to be non-null')
+  );
+  assert(
+    typeof item._md !== 'undefined',
+    () => new DataIntegrityError('Expected updatedAt to be defined')
+  );
+
+  assert(
+    item._v !== null,
+    () => new DataIntegrityError('Expected version to be non-null')
+  );
+  assert(
+    typeof item._v !== 'undefined',
+    () => new DataIntegrityError('Expected version to be defined')
+  );
 
   const result: UserSession = {
     createdAt: new Date(item._ct),

--- a/examples/user-session/user-session.test.ts
+++ b/examples/user-session/user-session.test.ts
@@ -367,7 +367,7 @@ describe('blindWriteUserSession()', () => {
 
     expect(updateResult.item.version).toBe(2);
 
-    const readResult = await readUserSession(createResult.item);
+    readUserSession(createResult.item);
 
     // cleanup, not part of test
     await deleteUserSession(createResult.item);
@@ -714,13 +714,13 @@ describe('updateUserSession()', () => {
       sessionId: faker.datatype.uuid(),
     });
 
-    const updateResult = await updateUserSession({
+    await updateUserSession({
       ...createResult.item,
       expires,
       session: {foo: 'bar'},
     });
 
-    const readResult = await readUserSession(createResult.item);
+    await readUserSession(createResult.item);
 
     // cleanup, not part of test
     await deleteUserSession(createResult.item);

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,10 +35,11 @@
         "@types/glob": "^8.0.0",
         "@types/jest": "^29.2.0",
         "@types/lodash": "^4.14.187",
-        "@types/node": "^18.11.17",
+        "@types/node": "^18",
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
         "aws-xray-sdk-core": "^3.4.0",
+        "cuid": "^2.1.8",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-babel": "^5.3.1",
@@ -8864,6 +8865,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==",
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -25457,11 +25464,12 @@
         "@types/glob": "^8.0.0",
         "@types/jest": "^29.2.0",
         "@types/lodash": "^4.14.187",
-        "@types/node": "18.11.17",
+        "@types/node": "^18",
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
         "aws-xray-sdk-core": "^3.4.0",
         "base64url": "^3.0.1",
+        "cuid": "*",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-babel": "^5.3.1",
@@ -32212,6 +32220,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
           "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+          "dev": true
+        },
+        "cuid": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+          "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==",
           "dev": true
         },
         "damerau-levenshtein": {
@@ -44229,6 +44243,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true
+    },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==",
       "dev": true
     },
     "damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
     "aws-xray-sdk-core": "^3.4.0",
+    "cuid": "^2.1.8",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-babel": "^5.3.1",

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -48,7 +48,15 @@ export function deleteItemTemplate(model: Model) {
  * Generates the query function for a table
  */
 export function queryTemplate(model: Model) {
-  if (!model.primaryKey.isComposite) {
+  let isQueryable = false;
+  if (model.primaryKey.isComposite) {
+    isQueryable = true;
+  }
+  if (model.secondaryIndexes.length > 0) {
+    isQueryable = true;
+  }
+
+  if (!isQueryable) {
     return '';
   }
 

--- a/src/codegen/actions/tables/table.ts
+++ b/src/codegen/actions/tables/table.ts
@@ -14,6 +14,7 @@ import {updateItemTpl} from './templates/update-item';
  */
 export function createItemTemplate(model: Model) {
   return createItemTpl({
+    hasPublicId: model.isPublicModel,
     key: makeKey(model.primaryKey),
     tableName: model.tableName,
     ttlConfig: model.ttlConfig,
@@ -26,6 +27,7 @@ export function createItemTemplate(model: Model) {
  */
 export function blindWriteTemplate(model: Model) {
   return blindWriteTpl({
+    hasPublicId: model.isPublicModel,
     key: makeKeyForBlind(model.primaryKey),
     tableName: model.tableName,
     ttlConfig: model.ttlConfig,
@@ -62,6 +64,7 @@ export function queryTemplate(model: Model) {
 
   return queryTpl({
     consistent: model.consistent,
+    isPublicModel: model.isPublicModel,
     primaryKey: model.primaryKey,
     secondaryIndexes: model.secondaryIndexes,
     tableName: model.tableName,
@@ -127,6 +130,7 @@ export function touchItemTemplate(model: Model) {
  */
 export function updateItemTemplate(model: Model) {
   return updateItemTpl({
+    hasPublicId: model.isPublicModel,
     key: makeKeyForRead(model.primaryKey),
     marshallPrimaryKey: objectToString(
       Object.fromEntries(

--- a/src/codegen/actions/tables/templates/helpers.ts
+++ b/src/codegen/actions/tables/templates/helpers.ts
@@ -34,7 +34,7 @@ export function marshallField(fieldName: string, isDate: boolean): string {
 
 /** Generates the template for producing the desired primary key or index column */
 export function makeKeyTemplate(
-  prefix: string,
+  prefix: string | undefined,
   fields: readonly GraphQLField<unknown, unknown>[] | readonly Field[],
   mode: 'blind' | 'create' | 'read'
 ): string {
@@ -64,7 +64,9 @@ export function makeKeyTemplate(
       }
       return `\${${marshallField(fieldName, isDateType)}}`;
     }),
-  ].join('#');
+  ]
+    .filter(Boolean)
+    .join('#');
 }
 
 /** Converts a compile time object to a runtime object */

--- a/src/codegen/actions/tables/templates/marshall.ts
+++ b/src/codegen/actions/tables/templates/marshall.ts
@@ -17,9 +17,11 @@ export function marshallTpl({
   table: {fields, secondaryIndexes, ttlConfig, typeName},
 }: MarshallTplInput): string {
   const requiredFields = fields
-    .filter((f) => f.isRequired)
+    .filter((f) => f.isRequired && f.fieldName !== 'publicId')
     .filter(({fieldName}) => fieldName !== 'id');
-  const optionalFields = fields.filter((f) => !f.isRequired);
+  const optionalFields = fields.filter(
+    (f) => !f.isRequired && f.fieldName !== 'publicId'
+  );
 
   // These are fields that are required on the object but have overridable
   // default behaviors
@@ -74,6 +76,7 @@ export function marshall${typeName}(input: ${inputTypeName}, now = new Date()): 
     .map(({fieldName}) => `'#${fieldName} = :${fieldName}',`)
     .join('\n')}
   ${secondaryIndexes
+    .filter(({name}) => name !== 'publicId')
     .map(({name, type}) =>
       type === 'gsi'
         ? [`'#${name}pk = :${name}pk',`, `'#${name}sk = :${name}sk',`]
@@ -94,6 +97,7 @@ ${requiredFields
   .map(({columnName, fieldName}) => `'#${fieldName}': '${columnName}',`)
   .join('\n')}
 ${secondaryIndexes
+  .filter(({name}) => name !== 'publicId')
   .map(({name, type}) =>
     type === 'gsi'
       ? [`'#${name}pk': '${name}pk',`, `'#${name}sk': '${name}sk',`]
@@ -128,6 +132,7 @@ ${secondaryIndexes
       .filter(Boolean)
       .join('\n')}
 ${secondaryIndexes
+  .filter(({name}) => name !== 'publicId')
   .map((index) =>
     index.type === 'gsi'
       ? [

--- a/src/codegen/actions/tables/templates/query.ts
+++ b/src/codegen/actions/tables/templates/query.ts
@@ -232,14 +232,11 @@ function indexToSortKey(index: PrimaryKeyConfig | SecondaryIndex): string {
   if ('name' in index) {
     return `
 if (input.index === '${index.name}') {
-  return ${makePartialKeyTemplate(
-    index.sortKeyPrefix ?? '',
-    index.sortKeyFields
-  )};
+  return ${makePartialKeyTemplate(index.sortKeyPrefix, index.sortKeyFields)};
 }`;
   }
   return `return ${makePartialKeyTemplate(
-    index.sortKeyPrefix ?? '',
+    index.sortKeyPrefix,
     index.sortKeyFields
   )}`;
 }
@@ -263,21 +260,13 @@ function makePartitionKeyForQuery(
 
       if (index.type === 'primary') {
         return `if (!('index' in input)) {
-  return \`${makeKeyTemplate(
-    partitionKeyPrefix ?? '',
-    partitionKeyFields,
-    'read'
-  )}\`
+  return \`${makeKeyTemplate(partitionKeyPrefix, partitionKeyFields, 'read')}\`
 }`;
       }
 
       return `
 if ('index' in input && input.index === '${index.name}') {
-  return \`${makeKeyTemplate(
-    partitionKeyPrefix ?? '',
-    partitionKeyFields,
-    'read'
-  )}\`;
+  return \`${makeKeyTemplate(partitionKeyPrefix, partitionKeyFields, 'read')}\`;
 }`;
     })
     .join('\n else ');
@@ -304,7 +293,7 @@ ${secondaryIndex.map(indexToSortKey).join('\n else ')};
 
 /** helper */
 function makePartialKeyTemplate(
-  prefix: string,
+  prefix: string | undefined,
   fields: readonly Field[]
 ): string {
   return `['${prefix}', ${fields

--- a/src/codegen/actions/tables/templates/query.ts
+++ b/src/codegen/actions/tables/templates/query.ts
@@ -176,9 +176,10 @@ function makeTypeSignature(
             );
           }
 
-          return Object.fromEntries(
-            index.partitionKeyFields.map(getTypeScriptTypeForField).sort()
-          );
+          return Object.fromEntries([
+            ...name,
+            ...index.partitionKeyFields.map(getTypeScriptTypeForField).sort(),
+          ]);
         }
 
         return [undefined, ...index.sortKeyFields].map((_, i) =>

--- a/src/codegen/actions/tables/templates/unmarshall.ts
+++ b/src/codegen/actions/tables/templates/unmarshall.ts
@@ -20,8 +20,10 @@ export function unmarshallTpl({
 export function unmarshall${typeName}(item: Record<string, any>): ${typeName} {
 
 ${requiredFields
+  // id is a computed field and therefore never present in the DynamoDB record
+  .filter(({fieldName}) => fieldName !== 'id')
   .map(({columnName, fieldName}) => {
-    return `if ('${columnName}' in item) {
+    return `
   assert(
     item.${columnName} !== null,
     () => new DataIntegrityError('Expected ${fieldName} to be non-null')
@@ -30,7 +32,7 @@ ${requiredFields
     typeof item.${columnName} !== 'undefined',
     () => new DataIntegrityError('Expected ${fieldName} to be defined')
   );
-}`;
+`;
   })
   .join('\n')}
 

--- a/src/codegen/actions/tables/templates/update-item.ts
+++ b/src/codegen/actions/tables/templates/update-item.ts
@@ -4,6 +4,7 @@ import {ensureTableTemplate} from './ensure-table';
 import {objectToString} from './helpers';
 
 export interface UpdateItemTplInput {
+  readonly hasPublicId: boolean;
   readonly key: Record<string, string>;
   readonly marshallPrimaryKey: string;
   readonly primaryKeyFields: string[];
@@ -14,6 +15,7 @@ export interface UpdateItemTplInput {
 
 /** template */
 export function updateItemTpl({
+  hasPublicId,
   marshallPrimaryKey,
   key,
   primaryKeyFields,
@@ -26,9 +28,11 @@ export function updateItemTpl({
     'id',
     'createdAt',
     'updatedAt',
-    ...(ttlConfig ? [ttlConfig.fieldName] : []),
+    hasPublicId && 'publicId',
+    ttlConfig?.fieldName,
   ]
-    .filter((fieldName) => !primaryKeyFields.includes(fieldName))
+    .filter(Boolean)
+    .filter((fieldName) => !primaryKeyFields.includes(fieldName as string))
     .map((f) => `'${f}'`)
     .sort();
   const outputTypeName = `Update${typeName}Output`;

--- a/src/codegen/cloudformation/table.ts
+++ b/src/codegen/cloudformation/table.ts
@@ -62,7 +62,13 @@ export function defineTable({
                 AttributeType: 'S',
               },
             ]
-          : [{AttributeName: `${index.name}pk`, AttributeType: 'S'}])
+          : [
+              {
+                AttributeName:
+                  index.name === 'publicId' ? 'publicId' : `${index.name}pk`,
+                AttributeType: 'S',
+              },
+            ])
       );
       const gsiKeySchema = index.isComposite
         ? [
@@ -77,7 +83,8 @@ export function defineTable({
           ]
         : [
             {
-              AttributeName: `${index.name}pk`,
+              AttributeName:
+                index.name === 'publicId' ? 'publicId' : `${index.name}pk`,
               KeyType: 'HASH',
             },
           ];

--- a/src/codegen/parser/parser.ts
+++ b/src/codegen/parser/parser.ts
@@ -183,13 +183,13 @@ function compareIndexes(
       assert.equal(
         index.isComposite,
         longIndex.isComposite,
-        `Please check the secondary index ${name} for the table ${tableName}. All indees of the same name must be of the same type (either partition or composite).`
+        `Please check the secondary index ${name} for the table ${tableName}. All indexes of the same name must be of the same type (either partition or composite).`
       );
 
       assert.equal(
         index.type,
         longIndex.type,
-        `Please check the secondary index ${name} for the table ${tableName}. All indees of the same name must be of the same type (either gsi or lsi).`
+        `Please check the secondary index ${name} for the table ${tableName}. All indexes of the same name must be of the same type (either gsi or lsi).`
       );
     } else {
       long.set(name, index);
@@ -433,6 +433,11 @@ export function getAliasForField(field: GraphQLField<unknown, unknown>) {
       return '_ct';
     case 'updatedAt':
       return '_md';
+    // do not snakeCase publicId (to support a legacy project). At some future
+    // point, this and the general index column issue of camel-not-snake needs
+    //
+    case 'publicId':
+      return 'publicId';
     default:
       return undefined;
   }

--- a/src/codegen/parser/types.ts
+++ b/src/codegen/parser/types.ts
@@ -65,7 +65,7 @@ export interface LSI {
   readonly name: string;
   readonly type: 'lsi';
   readonly sortKeyFields: readonly Field[];
-  readonly sortKeyPrefix: string;
+  readonly sortKeyPrefix?: string;
 }
 
 export type SecondaryIndex = GSI | LSI;
@@ -73,14 +73,14 @@ export type SecondaryIndex = GSI | LSI;
 export interface PartitionKey {
   readonly isComposite: false;
   readonly partitionKeyFields: readonly Field[];
-  readonly partitionKeyPrefix: string;
+  readonly partitionKeyPrefix?: string;
 }
 
 export interface CompositeKey {
   readonly isComposite: true;
-  readonly partitionKeyPrefix: string;
+  readonly partitionKeyPrefix?: string;
   readonly partitionKeyFields: Field[];
-  readonly sortKeyPrefix: string;
+  readonly sortKeyPrefix?: string;
   readonly sortKeyFields: Field[];
 }
 

--- a/src/codegen/parser/types.ts
+++ b/src/codegen/parser/types.ts
@@ -3,6 +3,7 @@ export interface Table {
   readonly enablePointInTimeRecovery: boolean;
   readonly enableStreaming: boolean;
   readonly hasCdc: boolean;
+  readonly hasPublicModels: boolean;
   readonly hasTtl: boolean;
   readonly libImportPath: string;
   readonly primaryKey: TablePrimaryKeyConfig;
@@ -27,6 +28,7 @@ export interface Model {
   readonly enablePointInTimeRecovery: boolean;
   readonly enableStreaming: boolean;
   readonly fields: readonly Field[];
+  readonly isPublicModel: boolean;
   readonly libImportPath: string;
   readonly tableName: string;
   readonly typeName: string;

--- a/src/codegen/schema.graphqls
+++ b/src/codegen/schema.graphqls
@@ -148,6 +148,20 @@ interface Model implements Timestamped & Versioned {
 }
 
 """
+Like Model, but includes a `publicId` field which, unline `id`, is semantically
+meaningless. Types implementing PublicModel will have an additional function,
+`queryByPublicId`, generated. If any of your models implement PublicModel, then
+the dependencies module must include an `idGenerator()`.
+"""
+interface PublicModel implements Model & Timestamped & Versioned {
+  createdAt: Date!
+  id: ID!
+  publicId: String!
+  updatedAt: Date!
+  version: Int!
+}
+
+"""
 Automatically adds a createdAt and updatedAt timestamp to the entity and sets
 them appropriately. The createdAt timestamp is only set on create, while the
 updatedAt timestamp is set on create and update.


### PR DESCRIPTION
- fix(actions): actually validate required fields are present during unmarshall
- fix: query secondary indexes
- refactor: allow prefix to be undefined
- style: fix lint warnings
- fix(actions): rethink the query template to handle composite _and_ simple keys
- test: add PublicModel
- feat(parser): add PublicModel
- feat: implement PublicModel queryable by publicId
