### PR TITLE
Insert SQS before CDC Handler'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@
 -   [Usage](#usage)
     -   [Codegen](#codegen)
     -   [Runtime](#runtime)
--   [Change Data Capture](#change-data-capture)
--   [Known Issues](#known-issues)
--   [Maintainer](#maintainer)
--   [Contribute](#contribute)
-    -   [Testing](#testing)
--   [License](#license)
+-   [Potential Costs](#potential-costs)
+    -   [Change Data Capture](#change-data-capture)
+    -   [Known Issues](#known-issues)
+    -   [Maintainer](#maintainer)
+    -   [Contribute](#contribute)
+        -   [Testing](#testing)
+    -   [License](#license)
 
 <!-- tocstop -->
 
@@ -86,6 +87,23 @@ All Errors thrown or rethrown by this library (except `AssertionError` which is
 the default Node `AssertionError`) or generated code are instance of
 `BaseDataLibraryError`, which is a subclass of `Error`. Rethrown errors always
 have a `cause` property that is the original error.
+
+# Potential Costs
+
+In general, any AWS resources genreated by this library will generate costs in
+the fractions of cents unless you hit scale. There are, however, a few sets of
+resources that will rack of costs faster initially (though, plateau, quickly as
+well).
+
+-   Each CDC directive will induce the creation of a KMS key, which costs
+    $1/month. This cannot be avoided without disabling encryption entirely
+    because there doesn't appear to be any way to grant EventBridge permission
+    to use the AWS-managed default key.
+-   A number of CloudWatch alarms are provisioned for each Lambda (depending on
+    its type). You should definitely enable these alarms in production, but by
+    default they're disabled unless the Parameter
+    `CreateChangeDataCaptureAlarms` is set. Each alarm costs $0.20/month and
+    there are around 5 alarms per Lambda.
 
 ## Change Data Capture
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 -   [Usage](#usage)
     -   [Codegen](#codegen)
     -   [Runtime](#runtime)
+-   [Change Data Capture](#change-data-capture)
 -   [Known Issues](#known-issues)
 -   [Maintainer](#maintainer)
 -   [Contribute](#contribute)
@@ -85,6 +86,35 @@ All Errors thrown or rethrown by this library (except `AssertionError` which is
 the default Node `AssertionError`) or generated code are instance of
 `BaseDataLibraryError`, which is a subclass of `Error`. Rethrown errors always
 have a `cause` property that is the original error.
+
+## Change Data Capture
+
+Several schema directives (`@enriches` and `@triggers` at time of writing)
+generate CloudFormation resources to support change data capture. In general,
+this means:
+
+-   The decorated model's table has a DynamoDB Stream enabled
+-   Regardless of the number of directives per model or the number of models,
+    exactly one lambda listens to the stream
+-   That Lambda function pushes each stream event to EventBridge
+-   Each directive has a corresponding EventBridge rule that push a filtered
+    subset of events into an SQS queue
+-   Each SQS queue has a corresponding Lambda that handles the events
+
+Why all the indirection? Filtering, multiple responders, and retries.
+
+There's no Dead Letter Queue for a DynamoDB stream, so we want the stream
+handler to be as failsafe as possible. That means it has to do as little as
+possible. Ideally, we'd push directly into an SQS queue, but then we only get
+one handler per table when we want one handler per directive per Model.
+
+EventBridge lets us 1. attach multiple handlers to the same DynamoDB stream
+event and 2. filter events those event so that the we only push matching events
+into the queue for a given model's directive.
+
+Finally, there's an SQS queue in front of each function so that we can push
+failures to its Dead Letter Queue and retry them manually when the underlying
+issue is fixed.
 
 ## Known Issues
 

--- a/examples/cdc-projection/__generated__/template.yml
+++ b/examples/cdc-projection/__generated__/template.yml
@@ -27,8 +27,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableAccount
-      Value:
-        Ref: TableAccount
     Value:
       Ref: TableAccount
   TableSubscription:
@@ -36,8 +34,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableSubscription
-      Value:
-        Ref: TableSubscription
     Value:
       Ref: TableSubscription
 Parameters:

--- a/examples/cdc-projection/__generated__/template.yml
+++ b/examples/cdc-projection/__generated__/template.yml
@@ -70,37 +70,17 @@ Resources:
         Target: es2020
     Properties:
       CodeUri: enricher--subscription--insert--account
-      DeadLetterQueue:
-        TargetArn:
-          Fn::GetAtt:
-            - FnHandlerSInsertAa23d7fc7EventBridgeDLQ
-            - Arn
-        Type: SQS
       Events:
-        INSERT:
+        Stream:
           Properties:
-            DeadLetterConfig:
-              Arn:
-                Fn::GetAtt:
-                  - FnHandlerSInsertAa23d7fc7DLQ
-                  - Arn
-            EventBusName: default
-            Pattern:
-              detail:
-                dynamodb:
-                  NewImage:
-                    _et:
-                      S:
-                        - Subscription
-              detail-type:
-                - INSERT
-              resources:
-                - Fn::GetAtt:
-                    - TableSubscription
-                    - Arn
-              source:
-                - TableSubscription.Subscription
-          Type: EventBridgeRule
+            BatchSize: 10
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            Queue:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7Queue
+                - Arn
+          Type: SQS
       MemorySize: 256
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -168,34 +148,6 @@ Resources:
       Threshold: 0
       TreatMissingData: notBreaching
     Type: AWS::CloudWatch::Alarm
-  FnHandlerSInsertAa23d7fc7EventBridgeDLQ:
-    Properties:
-      KmsMasterKeyId: alias/aws/sqs
-    Type: AWS::SQS::Queue
-  FnHandlerSInsertAa23d7fc7EventBridgeDLQDLQAlarm:
-    Condition: CreateChangeDataCaptureAlarmsCondition
-    Properties:
-      ActionsEnabled: true
-      AlarmActions: []
-      AlarmDescription: FnHandlerSInsertAa23d7fc7EventBridgeDLQ DLQ has messages
-      AlarmName: FnHandlerSInsertAa23d7fc7EventBridgeDLQ DLQ
-      ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 1
-      Dimensions:
-        - Name: QueueName
-          Value:
-            Fn::GetAtt:
-              - FnHandlerSInsertAa23d7fc7EventBridgeDLQ
-              - QueueName
-      EvaluationPeriods: 1
-      MetricName: ApproximateNumberOfMessagesVisible
-      Namespace: AWS/SQS
-      OKActions: []
-      Period: 60
-      Statistic: Sum
-      Threshold: 0
-      TreatMissingData: notBreaching
-    Type: AWS::CloudWatch::Alarm
   FnHandlerSInsertAa23d7fc7LambdaP99Alarm:
     Condition: CreateChangeDataCaptureAlarmsCondition
     Properties:
@@ -248,6 +200,65 @@ Resources:
       Threshold: 80
       TreatMissingData: notBreaching
     Type: AWS::CloudWatch::Alarm
+  FnHandlerSInsertAa23d7fc7Queue:
+    Properties:
+      KmsMasterKeyId: alias/aws/sqs
+      RedrivePolicy:
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - FnHandlerSInsertAa23d7fc7DLQ
+            - Arn
+        maxReceiveCount: 3
+      VisibilityTimeout: 320
+    Type: AWS::SQS::Queue
+  FnHandlerSInsertAa23d7fc7QueuePolicy:
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - sqs:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn:
+                  Fn::GetAtt:
+                    - FnHandlerSInsertAa23d7fc7Rule
+                    - Arn
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7Queue
+                - Arn
+            Sid: Allow EventBridge to send messages to the queue
+      Queues:
+        - Ref: FnHandlerSInsertAa23d7fc7Queue
+    Type: AWS::SQS::QueuePolicy
+  FnHandlerSInsertAa23d7fc7Rule:
+    Properties:
+      EventBusName: default
+      EventPattern:
+        detail:
+          dynamodb:
+            NewImage:
+              _et:
+                S:
+                  - Subscription
+        detail-type:
+          - INSERT
+        resources:
+          - Fn::GetAtt:
+              - TableSubscription
+              - Arn
+        source:
+          - TableSubscription.Subscription
+      Targets:
+        - Arn:
+            Fn::GetAtt:
+              - FnHandlerSInsertAa23d7fc7Queue
+              - Arn
+          Id: FnHandlerSInsertAa23d7fc7
+    Type: AWS::Events::Rule
   TableAccount:
     Properties:
       AttributeDefinitions:

--- a/examples/cdc-projection/__generated__/template.yml
+++ b/examples/cdc-projection/__generated__/template.yml
@@ -122,7 +122,11 @@ Resources:
     Type: AWS::CloudWatch::Alarm
   FnHandlerSInsertAa23d7fc7DLQ:
     Properties:
-      KmsMasterKeyId: alias/aws/sqs
+      KmsMasterKeyId:
+        Fn::If:
+          - IsProd
+          - Ref: FnHandlerSInsertAa23d7fc7QueueKey
+          - AWS::NoValue
     Type: AWS::SQS::Queue
   FnHandlerSInsertAa23d7fc7DLQDLQAlarm:
     Condition: CreateChangeDataCaptureAlarmsCondition
@@ -202,15 +206,90 @@ Resources:
     Type: AWS::CloudWatch::Alarm
   FnHandlerSInsertAa23d7fc7Queue:
     Properties:
-      KmsMasterKeyId: alias/aws/sqs
-      RedrivePolicy:
-        deadLetterTargetArn:
-          Fn::GetAtt:
-            - FnHandlerSInsertAa23d7fc7DLQ
-            - Arn
-        maxReceiveCount: 3
-      VisibilityTimeout: 320
+      Fn::If:
+        - IsProd
+        - KmsMasterKeyId:
+            Ref: FnHandlerSInsertAa23d7fc7QueueKey
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7DLQ
+                - Arn
+            maxReceiveCount: 3
+          VisibilityTimeout: 320
+        - RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7DLQ
+                - Arn
+            maxReceiveCount: 3
+          VisibilityTimeout: 320
     Type: AWS::SQS::Queue
+  FnHandlerSInsertAa23d7fc7QueueKey:
+    Condition: IsProd
+    Properties:
+      KeyPolicy:
+        Statement:
+          - Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource: '*'
+            Sid: Allow EventBridge to use the Key
+          - Action:
+              - kms:Create*
+              - kms:Describe*
+              - kms:Enable*
+              - kms:List*
+              - kms:Put*
+              - kms:Update*
+              - kms:Revoke*
+              - kms:Disable*
+              - kms:Get*
+              - kms:Delete*
+              - kms:ScheduleKeyDeletion
+              - kms:CancelKeyDeletion
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Resource: '*'
+            Sid: Allow administration of the key
+          - Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Condition:
+              StringEquals:
+                kms:CallerAccount:
+                  Fn::Sub: ${AWS::AccountId}
+                kms:ViaService: sqs.us-east-1.amazonaws.com
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Resource: '*'
+            Sid: >-
+              Allow access through Simple Queue Service (SQS) for all principals
+              in the account that are authorized to use SQS
+          - Action:
+              - kms:Describe*
+              - kms:Get*
+              - kms:List*
+              - kms:RevokeGrant
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Resource: '*'
+            Sid: Allow direct access to key metadata to the account
+        Version: '2012-10-17'
+      PendingWindowInDays: 7
+    Type: AWS::KMS::Key
   FnHandlerSInsertAa23d7fc7QueuePolicy:
     Properties:
       PolicyDocument:

--- a/examples/cdc-trigger/__generated__/template.yml
+++ b/examples/cdc-trigger/__generated__/template.yml
@@ -61,38 +61,17 @@ Resources:
         Target: es2020
     Properties:
       CodeUri: trigger--user-session--upsert
-      DeadLetterQueue:
-        TargetArn:
-          Fn::GetAtt:
-            - FnTriggerUSUpsert7d1674e2EventBridgeDLQ
-            - Arn
-        Type: SQS
       Events:
-        UPSERT:
+        Stream:
           Properties:
-            DeadLetterConfig:
-              Arn:
-                Fn::GetAtt:
-                  - FnTriggerUSUpsert7d1674e2DLQ
-                  - Arn
-            EventBusName: default
-            Pattern:
-              detail:
-                dynamodb:
-                  NewImage:
-                    _et:
-                      S:
-                        - UserSession
-              detail-type:
-                - INSERT
-                - MODIFY
-              resources:
-                - Fn::GetAtt:
-                    - TableUserSession
-                    - Arn
-              source:
-                - TableUserSession.UserSession
-          Type: EventBridgeRule
+            BatchSize: 10
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            Queue:
+              Fn::GetAtt:
+                - FnTriggerUSUpsert7d1674e2Queue
+                - Arn
+          Type: SQS
       MemorySize: 256
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -157,34 +136,6 @@ Resources:
       Threshold: 0
       TreatMissingData: notBreaching
     Type: AWS::CloudWatch::Alarm
-  FnTriggerUSUpsert7d1674e2EventBridgeDLQ:
-    Properties:
-      KmsMasterKeyId: alias/aws/sqs
-    Type: AWS::SQS::Queue
-  FnTriggerUSUpsert7d1674e2EventBridgeDLQDLQAlarm:
-    Condition: CreateChangeDataCaptureAlarmsCondition
-    Properties:
-      ActionsEnabled: true
-      AlarmActions: []
-      AlarmDescription: FnTriggerUSUpsert7d1674e2EventBridgeDLQ DLQ has messages
-      AlarmName: FnTriggerUSUpsert7d1674e2EventBridgeDLQ DLQ
-      ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 1
-      Dimensions:
-        - Name: QueueName
-          Value:
-            Fn::GetAtt:
-              - FnTriggerUSUpsert7d1674e2EventBridgeDLQ
-              - QueueName
-      EvaluationPeriods: 1
-      MetricName: ApproximateNumberOfMessagesVisible
-      Namespace: AWS/SQS
-      OKActions: []
-      Period: 60
-      Statistic: Sum
-      Threshold: 0
-      TreatMissingData: notBreaching
-    Type: AWS::CloudWatch::Alarm
   FnTriggerUSUpsert7d1674e2LambdaP99Alarm:
     Condition: CreateChangeDataCaptureAlarmsCondition
     Properties:
@@ -237,6 +188,66 @@ Resources:
       Threshold: 80
       TreatMissingData: notBreaching
     Type: AWS::CloudWatch::Alarm
+  FnTriggerUSUpsert7d1674e2Queue:
+    Properties:
+      KmsMasterKeyId: alias/aws/sqs
+      RedrivePolicy:
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - FnTriggerUSUpsert7d1674e2DLQ
+            - Arn
+        maxReceiveCount: 3
+      VisibilityTimeout: 320
+    Type: AWS::SQS::Queue
+  FnTriggerUSUpsert7d1674e2QueuePolicy:
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - sqs:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn:
+                  Fn::GetAtt:
+                    - FnTriggerUSUpsert7d1674e2Rule
+                    - Arn
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource:
+              Fn::GetAtt:
+                - FnTriggerUSUpsert7d1674e2Queue
+                - Arn
+            Sid: Allow EventBridge to send messages to the queue
+      Queues:
+        - Ref: FnTriggerUSUpsert7d1674e2Queue
+    Type: AWS::SQS::QueuePolicy
+  FnTriggerUSUpsert7d1674e2Rule:
+    Properties:
+      EventBusName: default
+      EventPattern:
+        detail:
+          dynamodb:
+            NewImage:
+              _et:
+                S:
+                  - UserSession
+        detail-type:
+          - INSERT
+          - MODIFY
+        resources:
+          - Fn::GetAtt:
+              - TableUserSession
+              - Arn
+        source:
+          - TableUserSession.UserSession
+      Targets:
+        - Arn:
+            Fn::GetAtt:
+              - FnTriggerUSUpsert7d1674e2Queue
+              - Arn
+          Id: FnTriggerUSUpsert7d1674e2
+    Type: AWS::Events::Rule
   TableUserSession:
     Properties:
       AttributeDefinitions:

--- a/examples/cdc-trigger/__generated__/template.yml
+++ b/examples/cdc-trigger/__generated__/template.yml
@@ -25,8 +25,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableUserSession
-      Value:
-        Ref: TableUserSession
     Value:
       Ref: TableUserSession
 Parameters:

--- a/examples/cdc-trigger/__generated__/template.yml
+++ b/examples/cdc-trigger/__generated__/template.yml
@@ -110,7 +110,11 @@ Resources:
     Type: AWS::CloudWatch::Alarm
   FnTriggerUSUpsert7d1674e2DLQ:
     Properties:
-      KmsMasterKeyId: alias/aws/sqs
+      KmsMasterKeyId:
+        Fn::If:
+          - IsProd
+          - Ref: FnTriggerUSUpsert7d1674e2QueueKey
+          - AWS::NoValue
     Type: AWS::SQS::Queue
   FnTriggerUSUpsert7d1674e2DLQDLQAlarm:
     Condition: CreateChangeDataCaptureAlarmsCondition
@@ -190,15 +194,90 @@ Resources:
     Type: AWS::CloudWatch::Alarm
   FnTriggerUSUpsert7d1674e2Queue:
     Properties:
-      KmsMasterKeyId: alias/aws/sqs
-      RedrivePolicy:
-        deadLetterTargetArn:
-          Fn::GetAtt:
-            - FnTriggerUSUpsert7d1674e2DLQ
-            - Arn
-        maxReceiveCount: 3
-      VisibilityTimeout: 320
+      Fn::If:
+        - IsProd
+        - KmsMasterKeyId:
+            Ref: FnTriggerUSUpsert7d1674e2QueueKey
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - FnTriggerUSUpsert7d1674e2DLQ
+                - Arn
+            maxReceiveCount: 3
+          VisibilityTimeout: 320
+        - RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - FnTriggerUSUpsert7d1674e2DLQ
+                - Arn
+            maxReceiveCount: 3
+          VisibilityTimeout: 320
     Type: AWS::SQS::Queue
+  FnTriggerUSUpsert7d1674e2QueueKey:
+    Condition: IsProd
+    Properties:
+      KeyPolicy:
+        Statement:
+          - Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource: '*'
+            Sid: Allow EventBridge to use the Key
+          - Action:
+              - kms:Create*
+              - kms:Describe*
+              - kms:Enable*
+              - kms:List*
+              - kms:Put*
+              - kms:Update*
+              - kms:Revoke*
+              - kms:Disable*
+              - kms:Get*
+              - kms:Delete*
+              - kms:ScheduleKeyDeletion
+              - kms:CancelKeyDeletion
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Resource: '*'
+            Sid: Allow administration of the key
+          - Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Condition:
+              StringEquals:
+                kms:CallerAccount:
+                  Fn::Sub: ${AWS::AccountId}
+                kms:ViaService: sqs.us-east-1.amazonaws.com
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Resource: '*'
+            Sid: >-
+              Allow access through Simple Queue Service (SQS) for all principals
+              in the account that are authorized to use SQS
+          - Action:
+              - kms:Describe*
+              - kms:Get*
+              - kms:List*
+              - kms:RevokeGrant
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Resource: '*'
+            Sid: Allow direct access to key metadata to the account
+        Version: '2012-10-17'
+      PendingWindowInDays: 7
+    Type: AWS::KMS::Key
   FnTriggerUSUpsert7d1674e2QueuePolicy:
     Properties:
       PolicyDocument:

--- a/examples/dependencies.ts
+++ b/examples/dependencies.ts
@@ -73,6 +73,7 @@ export const ddbDocClient = DynamoDBDocumentClient.from(ddb, translateConfig);
 
 /** From WithTelemetry */
 export function captureException(err: unknown) {
+  console.error({err});
   if (err instanceof Error) {
     getSegment()?.addError(err);
   } else {

--- a/examples/existing-json-template/__generated__/template.yml
+++ b/examples/existing-json-template/__generated__/template.yml
@@ -21,8 +21,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableUserLogin
-      Value:
-        Ref: TableUserLogin
     Value:
       Ref: TableUserLogin
 Parameters:

--- a/examples/existing-yml-schema/__generated__/template.yml
+++ b/examples/existing-yml-schema/__generated__/template.yml
@@ -25,8 +25,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableUserLogin
-      Value:
-        Ref: TableUserLogin
     Value:
       Ref: TableUserLogin
 Parameters:

--- a/examples/real-world-complex-cdc/__generated__/template.yml
+++ b/examples/real-world-complex-cdc/__generated__/template.yml
@@ -25,8 +25,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableCaseInstance
-      Value:
-        Ref: TableCaseInstance
     Value:
       Ref: TableCaseInstance
   TableCaseSummary:
@@ -34,8 +32,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableCaseSummary
-      Value:
-        Ref: TableCaseSummary
     Value:
       Ref: TableCaseSummary
   TableFileTiming:
@@ -43,8 +39,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableFileTiming
-      Value:
-        Ref: TableFileTiming
     Value:
       Ref: TableFileTiming
 Parameters:

--- a/examples/schema-directives/__generated__/template.yml
+++ b/examples/schema-directives/__generated__/template.yml
@@ -25,8 +25,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableAccount
-      Value:
-        Ref: TableAccount
     Value:
       Ref: TableAccount
   TableApplicationData:
@@ -34,8 +32,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableApplicationData
-      Value:
-        Ref: TableApplicationData
     Value:
       Ref: TableApplicationData
   TableUserSessions:
@@ -43,8 +39,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableUserSessions
-      Value:
-        Ref: TableUserSessions
     Value:
       Ref: TableUserSessions
 Parameters:

--- a/examples/single-table-design/__generated__/template.yml
+++ b/examples/single-table-design/__generated__/template.yml
@@ -27,8 +27,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableAccounts
-      Value:
-        Ref: TableAccounts
     Value:
       Ref: TableAccounts
   TableEmail:
@@ -36,8 +34,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableEmail
-      Value:
-        Ref: TableEmail
     Value:
       Ref: TableEmail
 Parameters:

--- a/examples/single-table-design/__generated__/template.yml
+++ b/examples/single-table-design/__generated__/template.yml
@@ -70,37 +70,17 @@ Resources:
         Target: es2020
     Properties:
       CodeUri: enricher--subscription--insert--account
-      DeadLetterQueue:
-        TargetArn:
-          Fn::GetAtt:
-            - FnHandlerSInsertAa23d7fc7EventBridgeDLQ
-            - Arn
-        Type: SQS
       Events:
-        INSERT:
+        Stream:
           Properties:
-            DeadLetterConfig:
-              Arn:
-                Fn::GetAtt:
-                  - FnHandlerSInsertAa23d7fc7DLQ
-                  - Arn
-            EventBusName: default
-            Pattern:
-              detail:
-                dynamodb:
-                  NewImage:
-                    _et:
-                      S:
-                        - Subscription
-              detail-type:
-                - INSERT
-              resources:
-                - Fn::GetAtt:
-                    - TableAccounts
-                    - Arn
-              source:
-                - TableAccounts.Subscription
-          Type: EventBridgeRule
+            BatchSize: 10
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            Queue:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7Queue
+                - Arn
+          Type: SQS
       MemorySize: 256
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -168,34 +148,6 @@ Resources:
       Threshold: 0
       TreatMissingData: notBreaching
     Type: AWS::CloudWatch::Alarm
-  FnHandlerSInsertAa23d7fc7EventBridgeDLQ:
-    Properties:
-      KmsMasterKeyId: alias/aws/sqs
-    Type: AWS::SQS::Queue
-  FnHandlerSInsertAa23d7fc7EventBridgeDLQDLQAlarm:
-    Condition: CreateChangeDataCaptureAlarmsCondition
-    Properties:
-      ActionsEnabled: true
-      AlarmActions: []
-      AlarmDescription: FnHandlerSInsertAa23d7fc7EventBridgeDLQ DLQ has messages
-      AlarmName: FnHandlerSInsertAa23d7fc7EventBridgeDLQ DLQ
-      ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 1
-      Dimensions:
-        - Name: QueueName
-          Value:
-            Fn::GetAtt:
-              - FnHandlerSInsertAa23d7fc7EventBridgeDLQ
-              - QueueName
-      EvaluationPeriods: 1
-      MetricName: ApproximateNumberOfMessagesVisible
-      Namespace: AWS/SQS
-      OKActions: []
-      Period: 60
-      Statistic: Sum
-      Threshold: 0
-      TreatMissingData: notBreaching
-    Type: AWS::CloudWatch::Alarm
   FnHandlerSInsertAa23d7fc7LambdaP99Alarm:
     Condition: CreateChangeDataCaptureAlarmsCondition
     Properties:
@@ -248,6 +200,65 @@ Resources:
       Threshold: 80
       TreatMissingData: notBreaching
     Type: AWS::CloudWatch::Alarm
+  FnHandlerSInsertAa23d7fc7Queue:
+    Properties:
+      KmsMasterKeyId: alias/aws/sqs
+      RedrivePolicy:
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - FnHandlerSInsertAa23d7fc7DLQ
+            - Arn
+        maxReceiveCount: 3
+      VisibilityTimeout: 320
+    Type: AWS::SQS::Queue
+  FnHandlerSInsertAa23d7fc7QueuePolicy:
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - sqs:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn:
+                  Fn::GetAtt:
+                    - FnHandlerSInsertAa23d7fc7Rule
+                    - Arn
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7Queue
+                - Arn
+            Sid: Allow EventBridge to send messages to the queue
+      Queues:
+        - Ref: FnHandlerSInsertAa23d7fc7Queue
+    Type: AWS::SQS::QueuePolicy
+  FnHandlerSInsertAa23d7fc7Rule:
+    Properties:
+      EventBusName: default
+      EventPattern:
+        detail:
+          dynamodb:
+            NewImage:
+              _et:
+                S:
+                  - Subscription
+        detail-type:
+          - INSERT
+        resources:
+          - Fn::GetAtt:
+              - TableAccounts
+              - Arn
+        source:
+          - TableAccounts.Subscription
+      Targets:
+        - Arn:
+            Fn::GetAtt:
+              - FnHandlerSInsertAa23d7fc7Queue
+              - Arn
+          Id: FnHandlerSInsertAa23d7fc7
+    Type: AWS::Events::Rule
   TableAccounts:
     Properties:
       AttributeDefinitions:

--- a/examples/single-table-design/__generated__/template.yml
+++ b/examples/single-table-design/__generated__/template.yml
@@ -122,7 +122,11 @@ Resources:
     Type: AWS::CloudWatch::Alarm
   FnHandlerSInsertAa23d7fc7DLQ:
     Properties:
-      KmsMasterKeyId: alias/aws/sqs
+      KmsMasterKeyId:
+        Fn::If:
+          - IsProd
+          - Ref: FnHandlerSInsertAa23d7fc7QueueKey
+          - AWS::NoValue
     Type: AWS::SQS::Queue
   FnHandlerSInsertAa23d7fc7DLQDLQAlarm:
     Condition: CreateChangeDataCaptureAlarmsCondition
@@ -202,15 +206,90 @@ Resources:
     Type: AWS::CloudWatch::Alarm
   FnHandlerSInsertAa23d7fc7Queue:
     Properties:
-      KmsMasterKeyId: alias/aws/sqs
-      RedrivePolicy:
-        deadLetterTargetArn:
-          Fn::GetAtt:
-            - FnHandlerSInsertAa23d7fc7DLQ
-            - Arn
-        maxReceiveCount: 3
-      VisibilityTimeout: 320
+      Fn::If:
+        - IsProd
+        - KmsMasterKeyId:
+            Ref: FnHandlerSInsertAa23d7fc7QueueKey
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7DLQ
+                - Arn
+            maxReceiveCount: 3
+          VisibilityTimeout: 320
+        - RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - FnHandlerSInsertAa23d7fc7DLQ
+                - Arn
+            maxReceiveCount: 3
+          VisibilityTimeout: 320
     Type: AWS::SQS::Queue
+  FnHandlerSInsertAa23d7fc7QueueKey:
+    Condition: IsProd
+    Properties:
+      KeyPolicy:
+        Statement:
+          - Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource: '*'
+            Sid: Allow EventBridge to use the Key
+          - Action:
+              - kms:Create*
+              - kms:Describe*
+              - kms:Enable*
+              - kms:List*
+              - kms:Put*
+              - kms:Update*
+              - kms:Revoke*
+              - kms:Disable*
+              - kms:Get*
+              - kms:Delete*
+              - kms:ScheduleKeyDeletion
+              - kms:CancelKeyDeletion
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Resource: '*'
+            Sid: Allow administration of the key
+          - Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Condition:
+              StringEquals:
+                kms:CallerAccount:
+                  Fn::Sub: ${AWS::AccountId}
+                kms:ViaService: sqs.us-east-1.amazonaws.com
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Resource: '*'
+            Sid: >-
+              Allow access through Simple Queue Service (SQS) for all principals
+              in the account that are authorized to use SQS
+          - Action:
+              - kms:Describe*
+              - kms:Get*
+              - kms:List*
+              - kms:RevokeGrant
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Resource: '*'
+            Sid: Allow direct access to key metadata to the account
+        Version: '2012-10-17'
+      PendingWindowInDays: 7
+    Type: AWS::KMS::Key
   FnHandlerSInsertAa23d7fc7QueuePolicy:
     Properties:
       PolicyDocument:

--- a/examples/user-login/__generated__/template.yml
+++ b/examples/user-login/__generated__/template.yml
@@ -21,8 +21,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableUserLogin
-      Value:
-        Ref: TableUserLogin
     Value:
       Ref: TableUserLogin
 Parameters:

--- a/examples/user-session/__generated__/template.yml
+++ b/examples/user-session/__generated__/template.yml
@@ -21,8 +21,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-TableUserSession
-      Value:
-        Ref: TableUserSession
     Value:
       Ref: TableUserSession
 Parameters:

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
         "@faker-js/faker": "^7.6.0",
-        "@graphql-codegen/cli": "^2.13.8",
+        "@graphql-codegen/cli": "^2.16.1",
         "@graphql-codegen/typescript": "^2.8.0",
         "@graphql-eslint/eslint-plugin": "^3.12.0",
         "@ianwremmel/data": "*",
@@ -3933,34 +3933,34 @@
       }
     },
     "node_modules/@graphql-codegen/cli": {
-      "version": "2.16.5",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.16.5.tgz",
-      "integrity": "sha512-XYPIp+q7fB0xAGSAoRykiTe4oY80VU+z+dw5nuv4mLY0+pv7+pa2C6Nwhdw7a65lXOhFviBApWCCZeqd54SMnA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.16.1.tgz",
+      "integrity": "sha512-11z3iSlsNCXcNNkoRKG3wCmT9XpLf7/GZG9bWGXkCoveWVRwnRmo37YakHdNV3hbcJ4iiGbR3Z+MX9gUTEPDVA==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "^7.18.13",
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.18.13",
-        "@graphql-codegen/core": "^2.6.8",
-        "@graphql-codegen/plugin-helpers": "^3.1.2",
+        "@graphql-codegen/core": "2.6.8",
+        "@graphql-codegen/plugin-helpers": "^3.1.1",
         "@graphql-tools/apollo-engine-loader": "^7.3.6",
         "@graphql-tools/code-file-loader": "^7.3.13",
         "@graphql-tools/git-loader": "^7.2.13",
         "@graphql-tools/github-loader": "^7.3.20",
         "@graphql-tools/graphql-file-loader": "^7.5.0",
         "@graphql-tools/json-file-loader": "^7.4.1",
-        "@graphql-tools/load": "^7.8.0",
-        "@graphql-tools/prisma-loader": "^7.2.49",
+        "@graphql-tools/load": "7.8.0",
+        "@graphql-tools/prisma-loader": "^7.2.7",
         "@graphql-tools/url-loader": "^7.13.2",
-        "@graphql-tools/utils": "^9.0.0",
-        "@whatwg-node/fetch": "^0.6.0",
+        "@graphql-tools/utils": "^8.9.0",
+        "@whatwg-node/fetch": "^0.5.0",
         "chalk": "^4.1.0",
         "chokidar": "^3.5.2",
         "cosmiconfig": "^7.0.0",
-        "cosmiconfig-typescript-loader": "^4.3.0",
+        "cosmiconfig-typescript-loader": "4.1.1",
         "debounce": "^1.2.0",
         "detect-indent": "^6.0.0",
-        "graphql-config": "^4.4.0",
+        "graphql-config": "4.3.6",
         "inquirer": "^8.0.0",
         "is-glob": "^4.0.1",
         "json-to-pretty-yaml": "^1.2.2",
@@ -3969,7 +3969,6 @@
         "shell-quote": "^1.7.3",
         "string-env-interpolation": "^1.0.1",
         "ts-log": "^2.2.3",
-        "ts-node": "^10.9.1",
         "tslib": "^2.4.0",
         "yaml": "^1.10.0",
         "yargs": "^17.0.0"
@@ -3982,6 +3981,97 @@
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/load": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.8.0.tgz",
+      "integrity": "sha512-l4FGgqMW0VOqo+NMYizwV8Zh+KtvVqOf93uaLo9wJ3sS3y/egPCgxPMDJJ/ufQZG3oZ/0oWeKt68qop3jY0yZg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/schema": "9.0.4",
+        "@graphql-tools/utils": "8.12.0",
+        "p-limit": "3.1.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.12.0.tgz",
+      "integrity": "sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/merge": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.6.tgz",
+      "integrity": "sha512-uUBokxXi89bj08P+iCvQk3Vew4vcfL5ZM6NTylWi8PIpoq4r5nJ625bRuN8h2uubEdRiH8ntN9M4xkd/j7AybQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "8.12.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.12.0.tgz",
+      "integrity": "sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/schema": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.4.tgz",
+      "integrity": "sha512-B/b8ukjs18fq+/s7p97P8L1VMrwapYc3N2KvdG/uNThSazRRn8GsBK0Nr+FH+mVKiUfb4Dno79e3SumZVoHuOQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/merge": "8.3.6",
+        "@graphql-tools/utils": "8.12.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.12.0.tgz",
+      "integrity": "sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/utils": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+      "integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/ansi-styles": {
@@ -4049,6 +4139,65 @@
         "node": ">=10"
       }
     },
+    "node_modules/@graphql-codegen/cli/node_modules/cosmiconfig-typescript-loader": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
+      "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "ts-node": ">=10",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/graphql-config": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.3.6.tgz",
+      "integrity": "sha512-i7mAPwc0LAZPnYu2bI8B6yXU5820Wy/ArvmOseDLZIu0OU1UTULEuexHo6ZcHXeT9NvGGaUPQZm8NV3z79YydA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/graphql-file-loader": "^7.3.7",
+        "@graphql-tools/json-file-loader": "^7.3.7",
+        "@graphql-tools/load": "^7.5.5",
+        "@graphql-tools/merge": "^8.2.6",
+        "@graphql-tools/url-loader": "^7.9.7",
+        "@graphql-tools/utils": "^8.6.5",
+        "cosmiconfig": "7.0.1",
+        "cosmiconfig-toml-loader": "1.0.0",
+        "cosmiconfig-typescript-loader": "^4.0.0",
+        "minimatch": "4.2.1",
+        "string-env-interpolation": "1.0.1",
+        "ts-node": "^10.8.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/graphql-config/node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@graphql-codegen/cli/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4056,6 +4205,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/supports-color": {
@@ -4068,6 +4229,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/value-or-promise": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@graphql-codegen/core": {
@@ -4922,6 +5092,12 @@
         "prettier": ">=2.7.1",
         "typescript": ">=4.7.4"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -6830,30 +7006,31 @@
       "dev": true
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.6.9.tgz",
-      "integrity": "sha512-JfrBCJdMu9n9OARc0e/hPHcD98/8Nz1CKSdGYDg6VbObDkV/Ys30xe5i/wPOatYbxuvatj1kfWeHf7iNX3i17w==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.5.4.tgz",
+      "integrity": "sha512-dR5PCzvOeS7OaW6dpIlPt+Ou3pak7IEG+ZVAV26ltcaiDB3+IpuvjqRdhsY6FKHcqBo1qD+S99WXY9Z6+9Rwnw==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
-        "@whatwg-node/node-fetch": "^0.0.5",
+        "abort-controller": "^3.0.0",
         "busboy": "^1.6.0",
-        "urlpattern-polyfill": "^6.0.2",
-        "web-streams-polyfill": "^3.2.1"
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
+        "node-fetch": "^2.6.7",
+        "undici": "^5.12.0",
+        "web-streams-polyfill": "^3.2.0"
       }
     },
-    "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.0.5.tgz",
-      "integrity": "sha512-hbccmaSZaItdsRuBKBEEhLoO+5oXJPxiyd0kG2xXd0Dh3Rt+vZn4pADHxuSiSHLd9CM+S2z4+IxlEGbWUgiz9g==",
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "dependencies": {
-        "@whatwg-node/events": "^0.0.2",
-        "busboy": "^1.6.0",
-        "tslib": "^2.3.1"
+        "event-target-shim": "^5.0.0"
       },
-      "peerDependencies": {
-        "@types/node": "^18.0.6"
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/acorn": {
@@ -8403,6 +8580,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/cosmiconfig-toml-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
+      "integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
+      "dev": true,
+      "dependencies": {
+        "@iarna/toml": "^2.2.5"
+      }
+    },
     "node_modules/cosmiconfig-typescript-loader": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
@@ -9648,6 +9834,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10057,6 +10252,34 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "dev": true
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/from2": {
@@ -15141,6 +15364,25 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-emoji": {
@@ -20841,6 +21083,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "@code-like-a-carpenter/exception": "^1.0.0",
+        "@code-like-a-carpenter/parallel": "^1.1.0",
         "@graphql-codegen/plugin-helpers": "^3.1.1",
         "@types/aws-lambda": "^8.10.108",
         "base64url": "^3.0.1",
@@ -3320,6 +3321,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@code-like-a-carpenter/env": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@code-like-a-carpenter/env/-/env-1.0.1.tgz",
+      "integrity": "sha512-oVtT00hvhRK65ngWnp2bXpKY3Z2uJjxBK4/Y47zvHYg7eRSGldCxBmGCZz5ZkO3nYEJaH0P/0tK0dmz4FVLF4g==",
+      "engines": {
+        "node": "18.x",
+        "npm": "8.x"
+      }
+    },
     "node_modules/@code-like-a-carpenter/exception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@code-like-a-carpenter/exception/-/exception-1.0.0.tgz",
@@ -3327,6 +3337,42 @@
       "engines": {
         "node": "18.x",
         "npm": "9.x"
+      }
+    },
+    "node_modules/@code-like-a-carpenter/parallel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@code-like-a-carpenter/parallel/-/parallel-1.1.0.tgz",
+      "integrity": "sha512-mDHbSUVC20f944TCGi9oFsIFPZcFtnTEfcEFwPHLvgpHQr+3ALMdXTza6OBqW2hlam+VSeYT+46WfvJJm3b80A==",
+      "dependencies": {
+        "@code-like-a-carpenter/telemetry": "1.1.0"
+      },
+      "engines": {
+        "node": "18.x",
+        "npm": "9.x"
+      }
+    },
+    "node_modules/@code-like-a-carpenter/telemetry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@code-like-a-carpenter/telemetry/-/telemetry-1.1.0.tgz",
+      "integrity": "sha512-11HzosjGJOJGJVg3RWud1MFGYS+3xN6lifRwJAlFek37guekIoNOjGCBIZyVQj6K3eb7vPaCbEy0qWtGYdoFlw==",
+      "dependencies": {
+        "@code-like-a-carpenter/env": "1.0.1",
+        "@code-like-a-carpenter/exception": "1.0.0",
+        "@opentelemetry/api": "1.4.0",
+        "aws-lambda": "^1.0.7",
+        "snake-case": "^3.0.4"
+      },
+      "engines": {
+        "node": "18.x",
+        "npm": "9.x"
+      }
+    },
+    "node_modules/@code-like-a-carpenter/telemetry/node_modules/@opentelemetry/api": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.0.tgz",
+      "integrity": "sha512-IgMK9i3sFGNUqPMbjABm0G26g0QCKCUBfglhQ7rQq6WcxbKfEHRcmwsoER4hZcuYqJgkYn2OeuoJIv7Jsftp7g==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -7383,12 +7429,98 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-lambda": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
+      "dependencies": {
+        "aws-sdk": "^2.814.0",
+        "commander": "^3.0.2",
+        "js-yaml": "^3.14.1",
+        "watchpack": "^2.0.0-beta.10"
+      },
+      "bin": {
+        "lambda": "bin/lambda"
+      }
+    },
+    "node_modules/aws-lambda/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aws-lambda/node_modules/commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+    },
+    "node_modules/aws-lambda/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1320.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1320.0.tgz",
+      "integrity": "sha512-oOsR+ClQZ6hmuAD/fu9gpsGMuLY1xG7m5SE/PDY3ZL4n34dmoXqwhQ3AHT1NTE0Z0sH1th6UqpHeHPS1trMOXw==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/aws-sdk/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/aws-xray-sdk-core": {
@@ -7713,7 +7845,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7899,7 +8030,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -9843,6 +9973,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10226,7 +10364,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -10349,8 +10486,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -10401,7 +10537,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -10531,6 +10666,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -10612,7 +10752,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -10623,8 +10762,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -10850,7 +10988,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -10904,7 +11041,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -10916,7 +11052,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -11232,8 +11367,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -11417,7 +11551,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -11499,7 +11632,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11581,6 +11713,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -11837,7 +11983,6 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
       "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -13737,6 +13882,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/joi": {
@@ -19090,6 +19243,15 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -19847,6 +20009,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/scuid": {
       "version": "1.1.0",
@@ -21252,11 +21419,25 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "node_modules/urlpattern-polyfill": {
       "version": "6.0.2",
@@ -21265,6 +21446,18 @@
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -21346,6 +21539,18 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/wcwidth": {
@@ -21457,7 +21662,6 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
       "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -21583,6 +21787,23 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
     "@faker-js/faker": "^7.6.0",
-    "@graphql-codegen/cli": "^2.13.8",
+    "@graphql-codegen/cli": "^2.16.1",
     "@graphql-codegen/typescript": "^2.8.0",
     "@graphql-eslint/eslint-plugin": "^3.12.0",
     "@ianwremmel/data": "*",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   },
   "dependencies": {
     "@code-like-a-carpenter/exception": "^1.0.0",
+    "@code-like-a-carpenter/parallel": "^1.1.0",
     "@graphql-codegen/plugin-helpers": "^3.1.1",
     "@types/aws-lambda": "^8.10.108",
     "base64url": "^3.0.1",

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -48,6 +48,7 @@ deploy_one () {
 
   local stackname
   stackname="$(get_stack_name "$example")"
+  stagename="development"
 
   local cmd
   case "$provider" in
@@ -56,6 +57,10 @@ deploy_one () {
       ;;
     localstack)
       cmd="samlocal"
+      # There seems to be a bug with localstack and conditionals. false
+      # conditions break the deploy without explanation, so in localstack where
+      # costs don't matter, we'll deploy in production mode.
+      stagename="production"
       ;;
     *)
       log "Unknown provider $provider"
@@ -70,6 +75,7 @@ deploy_one () {
     --no-fail-on-empty-changeset \
     --resolve-s3 \
     --stack-name "$stackname" \
+    --parameter-overrides "ParameterKey=StageName,ParameterValue=$stagename" \
     --region "${AWS_REGION:-us-east-1}"
 }
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -101,7 +101,7 @@ initialize_localstack () {
   log "Ensuing LocalStack is dependencies are installed"
   pip3 install --upgrade pyopenssl
   pip3 install localstack awscli-local[ver1] aws-sam-cli-local
-  docker pull localstack/localstack:1.3
+  docker pull localstack/localstack:1.4
 
   log "Starting LocalStack"
   docker-compose up -d

--- a/src/codegen/cloudformation/alarms.ts
+++ b/src/codegen/cloudformation/alarms.ts
@@ -257,11 +257,6 @@ export function makeHandlerAlarms(
         config.alarmActions,
         config.okActions
       ),
-      ...makeDLQAlarm(
-        `${functionName}EventBridgeDLQ`,
-        config.alarmActions,
-        config.okActions
-      ),
       ...makeLatencyP99Alarm(
         functionName,
         config.latencyP99Alarm,

--- a/src/codegen/cloudformation/cdc/lambdas.ts
+++ b/src/codegen/cloudformation/cdc/lambdas.ts
@@ -1,6 +1,6 @@
 import {filterNull} from '../../common/filters';
 import type {ChangeDataCaptureEvent, HandlerConfig} from '../../parser';
-import {makeDLQAlarm, makeHandlerAlarms} from '../alarms';
+import {makeHandlerAlarms} from '../alarms';
 import {combineFragments} from '../fragments/combine-fragments';
 import type {LambdaInput} from '../fragments/lambda';
 import {writeLambda} from '../fragments/lambda';
@@ -34,18 +34,24 @@ export function makeHandler({
 
   const {timeout, memorySize} = handlerConfig;
 
+  // this is the queue that the function listens to that eventbridge writes to
+  const q = `${functionName}Queue`;
+
+  // this is the queue that where messages go if they fail to be processed by
+  // the function
+  const dlq = `${functionName}DLQ`;
+
+  // dispatcher -> eventbridge
+  // eventbridge -> sqs queue
+  // sqs queue -> handler, dlq
+  const rule = `${functionName}Rule`;
+
   return combineFragments(
     makeLogGroup({functionName}),
     makeHandlerAlarms(functionName, handlerConfig),
     {
       resources: {
-        [`${functionName}DLQ`]: {
-          Properties: {
-            KmsMasterKeyId: 'alias/aws/sqs',
-          },
-          Type: 'AWS::SQS::Queue',
-        },
-        [`${functionName}EventBridgeDLQ`]: {
+        [dlq]: {
           Properties: {
             KmsMasterKeyId: 'alias/aws/sqs',
           },
@@ -58,36 +64,14 @@ export function makeHandler({
           },
           Properties: {
             CodeUri: codeUri,
-            DeadLetterQueue: {
-              TargetArn: {
-                'Fn::GetAtt': [`${functionName}EventBridgeDLQ`, 'Arn'],
-              },
-              Type: 'SQS',
-            },
             Events: {
-              [event]: {
+              Stream: {
                 Properties: {
-                  DeadLetterConfig: {
-                    Arn: {'Fn::GetAtt': [`${functionName}DLQ`, 'Arn']},
-                  },
-                  EventBusName: 'default',
-                  Pattern: {
-                    detail: {
-                      dynamodb: {
-                        NewImage: {
-                          _et: {
-                            S: [`${sourceModelName}`],
-                          },
-                        },
-                      },
-                    },
-                    'detail-type':
-                      event === 'UPSERT' ? ['INSERT', 'MODIFY'] : [event],
-                    resources: [{'Fn::GetAtt': [tableName, 'Arn']}],
-                    source: [`${tableName}.${sourceModelName}`],
-                  },
+                  BatchSize: 10,
+                  FunctionResponseTypes: ['ReportBatchItemFailures'],
+                  Queue: {'Fn::GetAtt': [q, 'Arn']},
                 },
-                Type: 'EventBridgeRule',
+                Type: 'SQS',
               },
             },
             MemorySize: memorySize,
@@ -118,6 +102,74 @@ export function makeHandler({
             Timeout: timeout,
           },
           Type: 'AWS::Serverless::Function',
+        },
+        [q]: {
+          Properties: {
+            KmsMasterKeyId: 'alias/aws/sqs',
+            RedrivePolicy: {
+              deadLetterTargetArn: {
+                'Fn::GetAtt': [dlq, 'Arn'],
+              },
+              maxReceiveCount: 3,
+            },
+            VisibilityTimeout: 320,
+          },
+          Type: 'AWS::SQS::Queue',
+        },
+        [`${q}Policy`]: {
+          Properties: {
+            PolicyDocument: {
+              Statement: [
+                {
+                  Action: ['sqs:SendMessage'],
+                  Condition: {
+                    ArnEquals: {
+                      'aws:SourceArn': {
+                        'Fn::GetAtt': [rule, 'Arn'],
+                      },
+                    },
+                  },
+                  Effect: 'Allow',
+                  Principal: {
+                    Service: 'events.amazonaws.com',
+                  },
+                  Resource: {
+                    'Fn::GetAtt': [q, 'Arn'],
+                  },
+                  Sid: 'Allow EventBridge to send messages to the queue',
+                },
+              ],
+            },
+            Queues: [{Ref: q}],
+          },
+          Type: 'AWS::SQS::QueuePolicy',
+        },
+        [rule]: {
+          Properties: {
+            EventBusName: 'default',
+            EventPattern: {
+              detail: {
+                dynamodb: {
+                  NewImage: {
+                    _et: {
+                      S: [`${sourceModelName}`],
+                    },
+                  },
+                },
+              },
+              'detail-type':
+                event === 'UPSERT' ? ['INSERT', 'MODIFY'] : [event],
+              resources: [{'Fn::GetAtt': [tableName, 'Arn']}],
+              source: [`${tableName}.${sourceModelName}`],
+            },
+            Targets: [
+              {
+                Arn: {'Fn::GetAtt': [q, 'Arn']},
+                Id: functionName,
+              },
+            ],
+          },
+          Type: 'AWS::Events::Rule',
         },
       },
     }

--- a/src/codegen/cloudformation/cdc/lambdas.ts
+++ b/src/codegen/cloudformation/cdc/lambdas.ts
@@ -53,7 +53,9 @@ export function makeHandler({
       resources: {
         [dlq]: {
           Properties: {
-            KmsMasterKeyId: 'alias/aws/sqs',
+            KmsMasterKeyId: {
+              'Fn::If': ['IsProd', {Ref: `${q}Key`}, 'AWS::NoValue'],
+            },
           },
           Type: 'AWS::SQS::Queue',
         },
@@ -105,16 +107,120 @@ export function makeHandler({
         },
         [q]: {
           Properties: {
-            KmsMasterKeyId: 'alias/aws/sqs',
-            RedrivePolicy: {
-              deadLetterTargetArn: {
-                'Fn::GetAtt': [dlq, 'Arn'],
+            'Fn::If': [
+              'IsProd',
+              {
+                KmsMasterKeyId: {
+                  Ref: `${q}Key`,
+                },
+                RedrivePolicy: {
+                  deadLetterTargetArn: {
+                    'Fn::GetAtt': [dlq, 'Arn'],
+                  },
+                  maxReceiveCount: 3,
+                },
+                VisibilityTimeout: 320,
               },
-              maxReceiveCount: 3,
-            },
-            VisibilityTimeout: 320,
+              {
+                RedrivePolicy: {
+                  deadLetterTargetArn: {
+                    'Fn::GetAtt': [dlq, 'Arn'],
+                  },
+                  maxReceiveCount: 3,
+                },
+                VisibilityTimeout: 320,
+              },
+            ],
           },
           Type: 'AWS::SQS::Queue',
+        },
+        [`${q}Key`]: {
+          Condition: 'IsProd',
+          Properties: {
+            KeyPolicy: {
+              Statement: [
+                {
+                  Action: ['kms:Decrypt', 'kms:GenerateDataKey'],
+                  Effect: 'Allow',
+                  Principal: {
+                    Service: 'events.amazonaws.com',
+                  },
+                  Resource: '*',
+                  Sid: 'Allow EventBridge to use the Key',
+                },
+                {
+                  Action: [
+                    'kms:Create*',
+                    'kms:Describe*',
+                    'kms:Enable*',
+                    'kms:List*',
+                    'kms:Put*',
+                    'kms:Update*',
+                    'kms:Revoke*',
+                    'kms:Disable*',
+                    'kms:Get*',
+                    'kms:Delete*',
+                    'kms:ScheduleKeyDeletion',
+                    'kms:CancelKeyDeletion',
+                  ],
+                  Effect: 'Allow',
+                  Principal: {
+                    AWS: {
+                      // eslint-disable-next-line no-template-curly-in-string
+                      'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:root',
+                    },
+                  },
+                  Resource: '*',
+                  Sid: 'Allow administration of the key',
+                },
+                {
+                  Action: [
+                    'kms:Encrypt',
+                    'kms:Decrypt',
+                    'kms:ReEncrypt*',
+                    'kms:GenerateDataKey*',
+                    'kms:CreateGrant',
+                    'kms:DescribeKey',
+                  ],
+                  Condition: {
+                    StringEquals: {
+                      'kms:CallerAccount': {
+                        // eslint-disable-next-line no-template-curly-in-string
+                        'Fn::Sub': '${AWS::AccountId}',
+                      },
+                      'kms:ViaService': 'sqs.us-east-1.amazonaws.com',
+                    },
+                  },
+                  Effect: 'Allow',
+                  Principal: {
+                    AWS: '*',
+                  },
+                  Resource: '*',
+                  Sid: 'Allow access through Simple Queue Service (SQS) for all principals in the account that are authorized to use SQS',
+                },
+                {
+                  Action: [
+                    'kms:Describe*',
+                    'kms:Get*',
+                    'kms:List*',
+                    'kms:RevokeGrant',
+                  ],
+                  Effect: 'Allow',
+                  Principal: {
+                    AWS: {
+                      // eslint-disable-next-line no-template-curly-in-string
+                      'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:root',
+                    },
+                  },
+                  Resource: '*',
+                  Sid: 'Allow direct access to key metadata to the account',
+                },
+              ],
+              Version: '2012-10-17',
+            },
+            PendingWindowInDays: 7,
+          },
+          Type: 'AWS::KMS::Key',
         },
         [`${q}Policy`]: {
           Properties: {

--- a/src/codegen/cloudformation/table.ts
+++ b/src/codegen/cloudformation/table.ts
@@ -184,7 +184,6 @@ export function defineTable({
         Description: `The name of the DynamoDB table for ${tableName}`,
         Export: {
           Name: {'Fn::Sub': `\${AWS::StackName}-${tableName}`},
-          Value: {Ref: tableName},
         },
         Value: {Ref: tableName},
       },

--- a/src/runtime/functions/common/handlers.ts
+++ b/src/runtime/functions/common/handlers.ts
@@ -1,6 +1,8 @@
+import {parallelMap} from '@code-like-a-carpenter/parallel';
 import {SpanKind} from '@opentelemetry/api';
-import type {Context, DynamoDBRecord, EventBridgeHandler} from 'aws-lambda';
+import type {Context, SQSHandler} from 'aws-lambda';
 
+import {assert} from '../../assert';
 import type {WithTelemetry} from '../../dependencies';
 import {makeLambdaOTelAttributes} from '../telemetry';
 
@@ -12,31 +14,85 @@ export type Callback = (
   context: Context
 ) => Promise<void>;
 
-export type Handler = EventBridgeHandler<
-  Exclude<DynamoDBRecord['eventName'], undefined> | string,
-  DynamoDBRecord,
-  unknown
->;
+export type Handler = SQSHandler;
 
 /** Makes a handler the dispatched event from a DynamoDB Stream. */
-export function makeEventBridgeHandler(
+
+/** Make a handler for an SQS event */
+export function makeSqsHandler(
   dependencies: WithTelemetry,
   cb: Callback
 ): Handler {
-  const {captureAsyncFunction, captureAsyncRootFunction} = dependencies;
-  return captureAsyncRootFunction(async (event, context) =>
-    captureAsyncFunction(
-      `${event.resources[0]} process`,
-      makeLambdaOTelAttributes(context),
+  const {captureAsyncFunction, captureAsyncRootFunction, captureException} =
+    dependencies;
+
+  return captureAsyncRootFunction(async (event, context) => {
+    const eventSource =
+      event.Records.reduce(
+        (acc, record) => acc.add(record.eventSource),
+        new Set<string>()
+      ).size === 1
+        ? event.Records[0].eventSource
+        : 'multiple_sources';
+
+    // Note that https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/instrumentation/aws-lambda/#sqs-event
+    // indicates that we should attach the event source context as a linked
+    // span, but until I remove `captureAsyncFunction` in favor of using OTel
+    // directly, that's not practical.
+    return captureAsyncFunction(
+      `${eventSource} process`,
+      {
+        ...makeLambdaOTelAttributes(context),
+        'faas.trigger': 'pubsub',
+        'message.operation': 'process',
+        'message.source.kind': 'queue',
+        'message.system': 'AmazonSQS',
+      },
       SpanKind.CONSUMER,
       async () => {
-        const ddbRecord = event.detail;
-        const unmarshalledRecord = unmarshallRecord(ddbRecord);
-        // Long run, the cb should return the payload and this code should
-        // update it, but I don't know that I want to deal with getting the
-        // appropriate create* method passed in here right now.
-        await cb(unmarshalledRecord, context);
+        const results = await parallelMap(event.Records, async (record) => {
+          await captureAsyncFunction(
+            `${eventSource} process`,
+            {
+              'faas.trigger': 'pubsub',
+              'message.operation': 'process',
+              'message.source.kind': 'queue',
+              'message.system': 'AmazonSQS',
+            },
+            SpanKind.CONSUMER,
+            async () => {
+              const eventBridgeRecord = JSON.parse(record.body);
+
+              assert(
+                'detail' in eventBridgeRecord,
+                'EventBridge record is missing "detail" field'
+              );
+              assert(
+                'dynamodb' in eventBridgeRecord.detail,
+                'EventBridge record is missing "detail.dynamodb" field'
+              );
+              const ddbRecord = eventBridgeRecord.detail;
+
+              const unmarshalledRecord = unmarshallRecord(ddbRecord);
+
+              try {
+                return await cb(unmarshalledRecord, context);
+              } catch (err) {
+                captureException(err);
+                throw err;
+              }
+            }
+          );
+        });
+
+        return {
+          batchItemFailures: results
+            .filter((result) => result.status === 'rejected')
+            .map((result, index) => ({
+              itemIdentifier: event.Records[index].messageId,
+            })),
+        };
       }
-    )
-  );
+    );
+  });
 }

--- a/src/runtime/functions/common/handlers.ts
+++ b/src/runtime/functions/common/handlers.ts
@@ -1,0 +1,42 @@
+import {SpanKind} from '@opentelemetry/api';
+import type {Context, DynamoDBRecord, EventBridgeHandler} from 'aws-lambda';
+
+import type {WithTelemetry} from '../../dependencies';
+import {makeLambdaOTelAttributes} from '../telemetry';
+
+import type {UnmarshalledDynamoDBRecord} from './unmarshall-record';
+import {unmarshallRecord} from './unmarshall-record';
+
+export type Callback = (
+  record: UnmarshalledDynamoDBRecord,
+  context: Context
+) => Promise<void>;
+
+export type Handler = EventBridgeHandler<
+  Exclude<DynamoDBRecord['eventName'], undefined> | string,
+  DynamoDBRecord,
+  unknown
+>;
+
+/** Makes a handler the dispatched event from a DynamoDB Stream. */
+export function makeEventBridgeHandler(
+  dependencies: WithTelemetry,
+  cb: Callback
+): Handler {
+  const {captureAsyncFunction, captureAsyncRootFunction} = dependencies;
+  return captureAsyncRootFunction(async (event, context) =>
+    captureAsyncFunction(
+      `${event.resources[0]} process`,
+      makeLambdaOTelAttributes(context),
+      SpanKind.CONSUMER,
+      async () => {
+        const ddbRecord = event.detail;
+        const unmarshalledRecord = unmarshallRecord(ddbRecord);
+        // Long run, the cb should return the payload and this code should
+        // update it, but I don't know that I want to deal with getting the
+        // appropriate create* method passed in here right now.
+        await cb(unmarshalledRecord, context);
+      }
+    )
+  );
+}

--- a/src/runtime/functions/enricher/make-enricher.ts
+++ b/src/runtime/functions/enricher/make-enricher.ts
@@ -4,7 +4,7 @@ import type {WithTelemetry} from '../../dependencies';
 import {NotFoundError} from '../../errors';
 import type {ResultType} from '../../types';
 import type {Handler} from '../common/handlers';
-import {makeEventBridgeHandler} from '../common/handlers';
+import {makeSqsHandler} from '../common/handlers';
 
 type Loader<SOURCE, TARGET> = (record: SOURCE) => Promise<TARGET>;
 type Creator<SOURCE, TARGET> = (record: SOURCE) => Promise<TARGET | undefined>;
@@ -45,7 +45,7 @@ export function makeEnricher<
 ): Handler {
   const {unmarshallSourceModel} = sdk;
 
-  return makeEventBridgeHandler(dependencies, async (unmarshalledRecord) => {
+  return makeSqsHandler(dependencies, async (unmarshalledRecord) => {
     assert(unmarshalledRecord.dynamodb?.NewImage);
     const source = unmarshallSourceModel(unmarshalledRecord.dynamodb?.NewImage);
     assert(source);

--- a/src/runtime/functions/table-dispatcher/make-table-dispatcher.ts
+++ b/src/runtime/functions/table-dispatcher/make-table-dispatcher.ts
@@ -24,21 +24,21 @@ async function handleRecord(
   try {
     const modelName = record.dynamodb?.NewImage?._et.S;
 
+    const entry = {
+      Detail: JSON.stringify(record),
+      DetailType: record.eventName,
+      Resources: record.eventSourceARN
+        ? [record.eventSourceARN.split('/stream')[0]]
+        : [],
+      Source: [tableName, modelName].join('.'),
+      Time: record.dynamodb?.ApproximateCreationDateTime
+        ? new Date(record.dynamodb.ApproximateCreationDateTime)
+        : undefined,
+    };
+
     await eventBridge.send(
       new PutEventsCommand({
-        Entries: [
-          {
-            Detail: JSON.stringify(record),
-            DetailType: record.eventName,
-            Resources: record.eventSourceARN
-              ? [record.eventSourceARN.split('/stream')[0]]
-              : [],
-            Source: [tableName, modelName].join('.'),
-            Time: record.dynamodb?.ApproximateCreationDateTime
-              ? new Date(record.dynamodb.ApproximateCreationDateTime)
-              : undefined,
-          },
-        ],
+        Entries: [entry],
       })
     );
   } catch (err) {

--- a/src/runtime/functions/trigger-handler/make-trigger-handler.ts
+++ b/src/runtime/functions/trigger-handler/make-trigger-handler.ts
@@ -1,6 +1,6 @@
 import type {WithTelemetry} from '../../dependencies';
 import type {Callback, Handler} from '../common/handlers';
-import {makeEventBridgeHandler} from '../common/handlers';
+import {makeSqsHandler} from '../common/handlers';
 
 /**
  * Makes an SQS handler that expects the payload to be a DynamoDB Stream Record.
@@ -9,5 +9,5 @@ export function makeTriggerHandler(
   dependencies: WithTelemetry,
   cb: Callback
 ): Handler {
-  return makeEventBridgeHandler(dependencies, cb);
+  return makeSqsHandler(dependencies, cb);
 }

--- a/src/runtime/functions/trigger-handler/make-trigger-handler.ts
+++ b/src/runtime/functions/trigger-handler/make-trigger-handler.ts
@@ -1,41 +1,13 @@
-import {SpanKind} from '@opentelemetry/api';
-import type {Context, DynamoDBRecord, EventBridgeHandler} from 'aws-lambda';
-
 import type {WithTelemetry} from '../../dependencies';
-import type {UnmarshalledDynamoDBRecord} from '../common/unmarshall-record';
-import {unmarshallRecord} from '../common/unmarshall-record';
-import {makeLambdaOTelAttributes} from '../telemetry';
-
-type Handler = (
-  record: UnmarshalledDynamoDBRecord,
-  context: Context
-) => Promise<void>;
+import type {Callback, Handler} from '../common/handlers';
+import {makeEventBridgeHandler} from '../common/handlers';
 
 /**
  * Makes an SQS handler that expects the payload to be a DynamoDB Stream Record.
  */
 export function makeTriggerHandler(
   dependencies: WithTelemetry,
-  cb: Handler
-): EventBridgeHandler<
-  Exclude<DynamoDBRecord['eventName'], undefined> | string,
-  DynamoDBRecord,
-  unknown
-> {
-  const {captureAsyncFunction, captureAsyncRootFunction} = dependencies;
-  return captureAsyncRootFunction(async (event, context) =>
-    captureAsyncFunction(
-      `${event.resources[0]} process`,
-      makeLambdaOTelAttributes(context),
-      SpanKind.CONSUMER,
-      async () => {
-        const ddbRecord = event.detail;
-        const unmarshalledRecord = unmarshallRecord(ddbRecord);
-        // Long run, the cb should return the payload and this code should
-        // update it, but I don't know that I want to deal with getting the
-        // appropriate create* method passed in here right now.
-        await cb(unmarshalledRecord, context);
-      }
-    )
-  );
+  cb: Callback
+): Handler {
+  return makeEventBridgeHandler(dependencies, cb);
 }


### PR DESCRIPTION
- fix(deps): undo breakage cause by bad @graphql-codegen/cli version
- refactor(runtime): split makeEnricher logic into standalone function
- refactor(runtime): share common event handler code between trigger and enricher factories
- fix: remove invalid property from stack outputs
- feat: insert an SQS queue between EventBridge and Lambda
- fix(examples): make sure we log errors to make debugging examples easier
- feat(cdc): encrypt the SQS queues
