### PR TITLE
feat(runtime): make several in-band attempts at handling CDC events

### DIFF
--- a/examples/cdc-projection/__generated__/actions.ts
+++ b/examples/cdc-projection/__generated__/actions.ts
@@ -93,7 +93,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/cdc-projection/__generated__/template.yml
+++ b/examples/cdc-projection/__generated__/template.yml
@@ -85,7 +85,7 @@ Resources:
               Fn::GetAtt:
                 - FnHandlerSInsertAa23d7fc7DLQ
                 - QueueName
-      Timeout: 30
+      Timeout: 90
     Type: AWS::Serverless::Function
   FnHandlerSInsertAa23d7fc7DLQ:
     Properties:

--- a/examples/cdc-trigger/__generated__/actions.ts
+++ b/examples/cdc-trigger/__generated__/actions.ts
@@ -77,7 +77,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/cdc-trigger/__generated__/template.yml
+++ b/examples/cdc-trigger/__generated__/template.yml
@@ -73,7 +73,7 @@ Resources:
               Fn::GetAtt:
                 - FnTriggerUSUpsert7d1674e2DLQ
                 - QueueName
-      Timeout: 30
+      Timeout: 90
     Type: AWS::Serverless::Function
   FnTriggerUSUpsert7d1674e2DLQ:
     Properties:

--- a/examples/existing-json-template/__generated__/actions.ts
+++ b/examples/existing-json-template/__generated__/actions.ts
@@ -75,7 +75,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/existing-yml-schema/__generated__/actions.ts
+++ b/examples/existing-yml-schema/__generated__/actions.ts
@@ -75,7 +75,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/real-world-complex-cdc/__generated__/actions.ts
+++ b/examples/real-world-complex-cdc/__generated__/actions.ts
@@ -131,7 +131,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/schema-directives/__generated__/actions.ts
+++ b/examples/schema-directives/__generated__/actions.ts
@@ -97,7 +97,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/single-table-design/__generated__/actions.ts
+++ b/examples/single-table-design/__generated__/actions.ts
@@ -93,7 +93,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/single-table-design/__generated__/template.yml
+++ b/examples/single-table-design/__generated__/template.yml
@@ -85,7 +85,7 @@ Resources:
               Fn::GetAtt:
                 - FnHandlerSInsertAa23d7fc7DLQ
                 - QueueName
-      Timeout: 30
+      Timeout: 90
     Type: AWS::Serverless::Function
   FnHandlerSInsertAa23d7fc7DLQ:
     Properties:

--- a/examples/user-login/__generated__/actions.ts
+++ b/examples/user-login/__generated__/actions.ts
@@ -75,7 +75,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/examples/user-session/__generated__/actions.ts
+++ b/examples/user-session/__generated__/actions.ts
@@ -77,7 +77,14 @@ export interface HandlerConfig {
 
 /** Reusable options for all generated lambdas */
 export interface LambdaConfig {
+  /** Measured in megabytes. */
   memory?: InputMaybe<Scalars['Int']>;
+  /**
+   * Measured in seconds. Reminder that handlers may need to do retries in-band, so
+   * consider making this a relatively high number and using alarms to catch
+   * timeouts rather than terminating the function. In order to make space for up
+   * to 5 retries, please add sixty seconds to your intended timeout.
+   */
   timeout?: InputMaybe<Scalars['Int']>;
 }
 

--- a/src/codegen/common-plugin-config.ts
+++ b/src/codegen/common-plugin-config.ts
@@ -7,5 +7,9 @@ export const defaultDispatcherConfig: DispatcherConfig = {
 
 export const defaultHandlerConfig: HandlerConfig = {
   memorySize: 256,
-  timeout: 30,
+  /**
+   * Needs to be large to 1. account for retries with exponential backoff and
+   * 2. to because a single lambda invocation will handle multiple updates.
+   */
+  timeout: 90,
 };

--- a/src/codegen/schema.graphqls
+++ b/src/codegen/schema.graphqls
@@ -30,7 +30,16 @@ directive @partitionKey(pkFields: [String!]!, pkPrefix: String) on OBJECT
 Reusable options for all generated lambdas
 """
 input LambdaConfig {
+  """
+  Measured in megabytes.
+  """
   memory: Int
+  """
+  Measured in seconds. Reminder that handlers may need to do retries in-band, so
+  consider making this a relatively high number and using alarms to catch
+  timeouts rather than terminating the function. In order to make space for up
+  to 5 retries, please add sixty seconds to your intended timeout.
+  """
   timeout: Int
 }
 

--- a/src/runtime/functions/common/handlers.ts
+++ b/src/runtime/functions/common/handlers.ts
@@ -13,6 +13,7 @@ import {assert} from '../../assert';
 import type {WithTelemetry} from '../../dependencies';
 import {makeLambdaOTelAttributes} from '../telemetry';
 
+import {retry} from './retry';
 import type {UnmarshalledDynamoDBRecord} from './unmarshall-record';
 import {unmarshallRecord} from './unmarshall-record';
 
@@ -96,7 +97,7 @@ export function makeSqsHandler(
               const unmarshalledRecord = unmarshallRecord(ddbRecord);
 
               try {
-                return await cb(unmarshalledRecord, context);
+                return await retry(() => cb(unmarshalledRecord, context));
               } catch (err) {
                 // Technically this exception is escaping the span, but only for
                 // use in crafting batchItemFailures. At this point, it's been

--- a/src/runtime/functions/common/retry.ts
+++ b/src/runtime/functions/common/retry.ts
@@ -1,0 +1,39 @@
+import {runWithNewSpan} from '@code-like-a-carpenter/telemetry';
+
+import {AlreadyExistsError, OptimisticLockingError} from '../../errors';
+
+export type VoidCallback = () => Promise<void>;
+
+/**
+ * Retries a callback up to 3 times in event of data freshness errors.
+ */
+export async function retry(cb: VoidCallback) {
+  const maxAttempts = 5;
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await runWithNewSpan(
+        'retry',
+        {
+          attributes: {
+            'com.code-like-a-carpenter.data.attempt': i,
+            'com.code-like-a-carpenter.data.total_attempts': maxAttempts,
+          },
+        },
+        cb
+      );
+      // terminate loop early because we've succeeded.
+      return;
+    } catch (err) {
+      if (
+        err instanceof AlreadyExistsError ||
+        err instanceof OptimisticLockingError
+      ) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, (i + 1) * (1 + 1) * 1000)
+        );
+      } else {
+        throw err;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some changes may induce races that lead to data freshness issues (trying
to create a record that already exists, trying to update an out of date
record, etc). While SQS's built-in retry behavior will typically handle
these scenarios and the system will eventually converge, these types of
errors will likely bubble up through your telemetry system and page you.
Instead, the library will now make update to five attemps (with
exponential backoff) during a single invocation which should both
prevent pages and converge faster (since SQS messages won't need to
return to the queue).
